### PR TITLE
Changed build mimic to do sonarQube scan and maven deploy only on master

### DIFF
--- a/.travis.build.sh
+++ b/.travis.build.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/bash
+
+if [ -z "${TRAVIS}" ]; then
+    echo "Local build - set TRAVIS=true for testing travis' behavior"
+    TRAVIS_BRANCH="local"
+    TRAVIS_PULL_REQUEST="false"
+fi
+
+if [ "${TRAVIS_BRANCH}" == "master" ]; then
+    if [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
+        echo "Building master"
+        mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar -Dsonar.host.url=http://sonar.ftk.de:9000  -Dsonar.login=${SONAR_TOKEN} -Dsonar.exclusions=**/xtext-gen/**/*,**/xtend-gen/**/*,**/emf-gen/**/*
+        mvn deploy -DskipTests=true -Dmaven.javadoc.skip=true
+    else
+        echo "Building pull request"
+        mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent verify
+    fi
+else
+    echo "Building branch ${TRAVIS_BRANCH}"
+    mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent verify
+fi

--- a/.travis.settings.xml
+++ b/.travis.settings.xml
@@ -5,13 +5,13 @@
   <servers>
     <server>
       <id>openconjurer</id>
-      <username>{NEXUS_USERNAME}</username>
-      <password>{NEXUS_PASSWORD}</password>
+      <username>${env.NEXUS_USERNAME}</username>
+      <password>${env.NEXUS_PASSWORD}</password>
     </server>
     <server>
       <id>openconjurer-snapshots</id>
-      <username>{NEXUS_USERNAME}</username>
-      <password>{NEXUS_PASSWORD}</password>
+      <username>${env.NEXUS_USERNAME}</username>
+      <password>${env.NEXUS_PASSWORD}</password>
     </server>
   </servers>
 </settings>

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ install: true
 env:
   - SONAR_HOST=http://sonar.ftk.de:9000
 script:
-  - sed -e "s/{NEXUS_USERNAME}/$NEXUS_USERNAME/g" -e "s/{NEXUS_PASSWORD}/$NEXUS_PASSWORD/g" <.travis.settings.xml >$HOME/.m2/settings.xml
-  - mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar -Dsonar.host.url=http://sonar.ftk.de:9000  -Dsonar.login=${SONAR_TOKEN} -Dsonar.exclusions=**/xtext-gen/**/*,**/xtend-gen/**/*,**/emf-gen/**/*
-  - mvn deploy -DskipTests=true -Dmaven.javadoc.skip=true
+  - cp .travis.settings.xml $HOME/.m2/settings.xml
+  - bash ./.travis.build.sh
+
 # Cache local maven repository to speed up build
 # Remove packages from local maven repository before caching to avoid errors when refactoring maven structure
 before_cache:


### PR DESCRIPTION
The current sapl-policy-engine build deploys snapshot builds to the maven repository from every branch (and also performs sonarQube scans in every branch).

This yields unstable results in dependent project when API changes are prepared in a branch and on the currently used sonarQube server (which does not support branches yet).