### PR TITLE
[sapl-hamcrest] implement AuthorizationDecision Matcher & move all static factory methods to single class "Matchers"

### DIFF
--- a/sapl-hamcrest/pom.xml
+++ b/sapl-hamcrest/pom.xml
@@ -38,6 +38,11 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>io.sapl</groupId>
+			<artifactId>sapl-pdp-api</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
 			<groupId>org.hamcrest</groupId>
 			<artifactId>hamcrest</artifactId>
 		</dependency>

--- a/sapl-hamcrest/src/main/java/io/sapl/hamcrest/HasAdvice.java
+++ b/sapl-hamcrest/src/main/java/io/sapl/hamcrest/HasAdvice.java
@@ -1,0 +1,62 @@
+package io.sapl.hamcrest;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.sapl.api.pdp.AuthorizationDecision;
+
+public class HasAdvice extends TypeSafeDiagnosingMatcher<AuthorizationDecision>  {
+	
+	private final Optional<Matcher<? super JsonNode>> jsonMatcher;
+
+	public HasAdvice(Matcher<? super JsonNode> jsonMatcher) {
+		super(AuthorizationDecision.class);
+		this.jsonMatcher = Optional.of(Objects.requireNonNull(jsonMatcher));
+	}
+
+	public HasAdvice() {
+		super(AuthorizationDecision.class);
+		this.jsonMatcher = Optional.empty();
+	}
+	
+	@Override
+	public void describeTo(Description description) {
+		description.appendText("the decision has an advice equals ");
+		this.jsonMatcher.ifPresentOrElse(matcher -> description.appendDescriptionOf(matcher),
+				() -> description.appendText("any advice"));
+	}
+
+	@Override
+	protected boolean matchesSafely(AuthorizationDecision decision, Description mismatchDescription) {
+		if(decision.getAdvices().isEmpty())
+		{
+			mismatchDescription.appendText("decision didn't contain any advices");
+			return false;
+		}
+		
+		if (jsonMatcher.isEmpty()) {
+			return true;
+		} 
+		
+		boolean containsAdvice = false;
+		
+        for(JsonNode node : decision.getAdvices().get()) {
+        	if(this.jsonMatcher.get().matches(node))
+        		containsAdvice = true;
+        };
+        
+		if(containsAdvice) {
+			return true;
+		} else {
+			mismatchDescription.appendText("no advice matched");
+			return false;
+		}
+	}
+
+}

--- a/sapl-hamcrest/src/main/java/io/sapl/hamcrest/HasAdviceContainingKeyValue.java
+++ b/sapl-hamcrest/src/main/java/io/sapl/hamcrest/HasAdviceContainingKeyValue.java
@@ -1,0 +1,76 @@
+package io.sapl.hamcrest;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.sapl.api.pdp.AuthorizationDecision;
+
+public class HasAdviceContainingKeyValue extends TypeSafeDiagnosingMatcher<AuthorizationDecision>  {
+	
+	private final String key;
+	private final Optional<Matcher<? super JsonNode>> valueMatcher;
+
+
+	public HasAdviceContainingKeyValue(String key, Matcher<? super JsonNode> value) {
+		super(AuthorizationDecision.class);
+		this.key = Objects.requireNonNull(key);
+		this.valueMatcher = Optional.of(Objects.requireNonNull(value));
+	}
+	
+	public HasAdviceContainingKeyValue(String key) {
+		super(AuthorizationDecision.class);
+		this.key = Objects.requireNonNull(key);
+		this.valueMatcher = Optional.empty();
+	}
+	
+	@Override
+	public void describeTo(Description description) {
+		description.appendText(String.format("the decision has an advice containing key %s", this.key));
+
+		this.valueMatcher.ifPresentOrElse(matcher -> description.appendText(" with ").appendDescriptionOf(matcher),
+				() -> description.appendText(" with any value"));
+	}
+
+	@Override
+	protected boolean matchesSafely(AuthorizationDecision decision, Description mismatchDescription) {
+		if(decision.getAdvices().isEmpty())
+		{
+			mismatchDescription.appendText("decision didn't contain any advices");
+			return false;
+		}
+		
+		
+		boolean containsAdvice = false;
+		
+		//iterate over all advices
+        for(JsonNode advice : decision.getAdvices().get()) {
+        	var iterator = advice.fields();
+        	//iterate over fields in this advice
+        	while (iterator.hasNext()) {
+        	    var entry = iterator.next();
+        	    //check if key/value exists
+        	    if(entry.getKey().equals(this.key))  {
+        	    	if(this.valueMatcher.isEmpty()) {
+        	    		containsAdvice = true;        	    		
+        	    	} else if(this.valueMatcher.get().matches(entry.getValue())) {
+            	    	containsAdvice = true;
+        	    	}
+        		}
+        	}
+        };
+        
+		if(containsAdvice) {
+			return true;
+		} else {
+			mismatchDescription.appendText("no entry in all advices matched");
+			return false;
+		}
+	}
+
+}

--- a/sapl-hamcrest/src/main/java/io/sapl/hamcrest/HasAdviceMatching.java
+++ b/sapl-hamcrest/src/main/java/io/sapl/hamcrest/HasAdviceMatching.java
@@ -1,0 +1,50 @@
+package io.sapl.hamcrest;
+
+import java.util.Objects;
+import java.util.function.Predicate;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.sapl.api.pdp.AuthorizationDecision;
+
+public class HasAdviceMatching extends TypeSafeDiagnosingMatcher<AuthorizationDecision>  {
+	
+	private final Predicate<? super JsonNode> predicate;
+
+	public HasAdviceMatching(Predicate<? super JsonNode> jsonPredicate) {
+		super(AuthorizationDecision.class);
+		this.predicate = Objects.requireNonNull(jsonPredicate);
+	}
+
+	@Override
+	public void describeTo(Description description) {
+		description.appendText("the decision has an advice matching the predicate");
+	}
+
+	@Override
+	protected boolean matchesSafely(AuthorizationDecision decision, Description mismatchDescription) {
+		if(decision.getAdvices().isEmpty())
+		{
+			mismatchDescription.appendText("decision didn't contain any advices");
+			return false;
+		}
+
+		boolean containsAdvice = false;
+		
+        for(JsonNode node : decision.getAdvices().get()) {
+        	if(this.predicate.test(node))
+        		containsAdvice = true;
+        };
+        
+		if(containsAdvice) {
+			return true;
+		} else {
+			mismatchDescription.appendText("no advice matched");
+			return false;
+		}
+	}
+
+}

--- a/sapl-hamcrest/src/main/java/io/sapl/hamcrest/HasObligation.java
+++ b/sapl-hamcrest/src/main/java/io/sapl/hamcrest/HasObligation.java
@@ -1,0 +1,62 @@
+package io.sapl.hamcrest;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.sapl.api.pdp.AuthorizationDecision;
+
+public class HasObligation extends TypeSafeDiagnosingMatcher<AuthorizationDecision>  {
+	
+	private final Optional<Matcher<? super JsonNode>> jsonMatcher;
+
+	public HasObligation(Matcher<? super JsonNode> jsonMatcher) {
+		super(AuthorizationDecision.class);
+		this.jsonMatcher = Optional.of(Objects.requireNonNull(jsonMatcher));
+	}
+
+	public HasObligation() {
+		super(AuthorizationDecision.class);
+		this.jsonMatcher = Optional.empty();
+	}
+	
+	
+	@Override
+	public void describeTo(Description description) {
+		description.appendText("the decision has an obligation equals ");
+		this.jsonMatcher.ifPresentOrElse(matcher -> description.appendDescriptionOf(matcher),
+				() -> description.appendText("any obligation"));
+	}
+
+	@Override
+	protected boolean matchesSafely(AuthorizationDecision decision, Description mismatchDescription) {
+		if(decision.getObligations().isEmpty())
+		{
+			mismatchDescription.appendText("decision didn't contain any obligations");
+			return false;
+		}
+		
+		if (jsonMatcher.isEmpty()) {
+			return true;
+		} 
+		
+		boolean containsObligation = false;
+		
+        for(JsonNode node : decision.getObligations().get()) {
+        	if(this.jsonMatcher.get().matches(node))
+        		containsObligation = true;
+        };
+        
+		if(containsObligation) {
+			return true;
+		} else {
+			mismatchDescription.appendText("no obligation matched");
+			return false;
+		}
+	}
+}

--- a/sapl-hamcrest/src/main/java/io/sapl/hamcrest/HasObligationContainingKeyValue.java
+++ b/sapl-hamcrest/src/main/java/io/sapl/hamcrest/HasObligationContainingKeyValue.java
@@ -1,0 +1,76 @@
+package io.sapl.hamcrest;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.sapl.api.pdp.AuthorizationDecision;
+
+public class HasObligationContainingKeyValue extends TypeSafeDiagnosingMatcher<AuthorizationDecision>  {
+	
+	private final String key;
+	private final Optional<Matcher<? super JsonNode>> valueMatcher;
+
+
+	public HasObligationContainingKeyValue(String key, Matcher<? super JsonNode> value) {
+		super(AuthorizationDecision.class);
+		this.key = Objects.requireNonNull(key);
+		this.valueMatcher = Optional.of(Objects.requireNonNull(value));
+	}
+	
+	public HasObligationContainingKeyValue(String key) {
+		super(AuthorizationDecision.class);
+		this.key = Objects.requireNonNull(key);
+		this.valueMatcher = Optional.empty();
+	}
+
+	@Override
+	public void describeTo(Description description) {
+		description.appendText(String.format("the decision has an obligation containing key %s", this.key));
+
+		this.valueMatcher.ifPresentOrElse(matcher -> description.appendText(" with ").appendDescriptionOf(matcher),
+				() -> description.appendText(" with any value"));
+	}
+
+	@Override
+	protected boolean matchesSafely(AuthorizationDecision decision, Description mismatchDescription) {
+		if(decision.getObligations().isEmpty())
+		{
+			mismatchDescription.appendText("decision didn't contain any obligations");
+			return false;
+		}
+		
+		
+		boolean containsObligationKeyValue = false;
+		
+		//iterate over all obligations
+        for(JsonNode obligation : decision.getObligations().get()) {
+        	var iterator = obligation.fields();
+        	//iterate over fields in this obligation
+        	while (iterator.hasNext()) {
+        	    var entry = iterator.next();
+        	    //check if key/value exists
+        	    if(entry.getKey().equals(this.key))  {
+        	    	if(this.valueMatcher.isEmpty()) {
+        	    		containsObligationKeyValue = true;        	    		
+        	    	} else if(this.valueMatcher.get().matches(entry.getValue())) {
+        	    		containsObligationKeyValue = true;
+        	    	}
+        		}
+        	}
+        };
+        
+		if(containsObligationKeyValue) {
+			return true;
+		} else {
+			mismatchDescription.appendText("no entry in all obligations matched");
+			return false;
+		}
+	}
+
+}

--- a/sapl-hamcrest/src/main/java/io/sapl/hamcrest/HasObligationMatching.java
+++ b/sapl-hamcrest/src/main/java/io/sapl/hamcrest/HasObligationMatching.java
@@ -1,0 +1,50 @@
+package io.sapl.hamcrest;
+
+import java.util.Objects;
+import java.util.function.Predicate;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.sapl.api.pdp.AuthorizationDecision;
+
+public class HasObligationMatching extends TypeSafeDiagnosingMatcher<AuthorizationDecision>  {
+	
+	private final Predicate<? super JsonNode> predicate;
+
+	public HasObligationMatching(Predicate<? super JsonNode> jsonPredicate) {
+		super(AuthorizationDecision.class);
+		this.predicate = Objects.requireNonNull(jsonPredicate);
+	}
+
+	@Override
+	public void describeTo(Description description) {
+		description.appendText("the decision has an obligation matching the predicate");
+	}
+
+	@Override
+	protected boolean matchesSafely(AuthorizationDecision decision, Description mismatchDescription) {
+		if(decision.getObligations().isEmpty())
+		{
+			mismatchDescription.appendText("decision didn't contain any obligations");
+			return false;
+		}
+		
+		boolean containsObligation = false;
+		
+        for(JsonNode node : decision.getObligations().get()) {
+        	if(this.predicate.test(node))
+        		containsObligation = true;
+        };
+        
+		if(containsObligation) {
+			return true;
+		} else {
+			mismatchDescription.appendText("no obligation matched");
+			return false;
+		}
+	}
+
+}

--- a/sapl-hamcrest/src/main/java/io/sapl/hamcrest/IsDecision.java
+++ b/sapl-hamcrest/src/main/java/io/sapl/hamcrest/IsDecision.java
@@ -1,0 +1,43 @@
+package io.sapl.hamcrest;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import io.sapl.api.pdp.AuthorizationDecision;
+import io.sapl.api.pdp.Decision;
+
+public class IsDecision extends TypeSafeDiagnosingMatcher<AuthorizationDecision> {
+	
+	private Optional<Decision> expectedDecision;
+	
+	public IsDecision(Decision expected) {
+		super(AuthorizationDecision.class);
+		this.expectedDecision = Optional.of(Objects.requireNonNull(expected));
+	}
+	
+	public IsDecision() {
+		super(AuthorizationDecision.class);
+		this.expectedDecision = Optional.empty();
+	}
+	
+	@Override
+	public void describeTo(Description description) {
+		description.appendText("the decision is ");
+		this.expectedDecision.ifPresentOrElse(expected -> description.appendText(expected.name()),
+				() -> description.appendText("any decision"));
+	}
+
+	@Override
+	protected boolean matchesSafely(AuthorizationDecision decision, Description mismatchDescription) {
+		if (this.expectedDecision.isEmpty() || this.expectedDecision.get() == decision.getDecision()) {
+			return true;
+		} else {
+			mismatchDescription.appendText("was decision of " + this.expectedDecision.get().name());
+			return false;
+		}
+	}
+
+}

--- a/sapl-hamcrest/src/main/java/io/sapl/hamcrest/IsResource.java
+++ b/sapl-hamcrest/src/main/java/io/sapl/hamcrest/IsResource.java
@@ -1,0 +1,53 @@
+package io.sapl.hamcrest;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.sapl.api.pdp.AuthorizationDecision;
+
+public class IsResource extends TypeSafeDiagnosingMatcher<AuthorizationDecision> {
+
+	private final Optional<Matcher<? super JsonNode>> jsonMatcher;
+
+	public IsResource(Matcher<? super JsonNode> jsonMatcher) {
+		super(AuthorizationDecision.class);
+		this.jsonMatcher = Optional.of(Objects.requireNonNull(jsonMatcher));
+	}
+
+	public IsResource() {
+		super(AuthorizationDecision.class);
+		this.jsonMatcher = Optional.empty();
+	}
+
+	@Override
+	public void describeTo(Description description) {
+		description.appendText("a resource with");
+		jsonMatcher.ifPresentOrElse(matcher -> description.appendDescriptionOf(matcher),
+				() -> description.appendText(" any JsonNode"));
+	}
+
+	@Override
+	protected boolean matchesSafely(AuthorizationDecision decision, Description mismatchDescription) {
+		if(decision.getResource().isEmpty())
+		{
+			mismatchDescription.appendText("decision didn't contain a resource");
+			return false;
+		}
+		
+		var json = decision.getResource().get();
+		if (jsonMatcher.isEmpty() || jsonMatcher.get().matches(json)) {
+			return true;
+		} else {
+			mismatchDescription.appendText("was resource that ");
+			jsonMatcher.get().describeMismatch(json, mismatchDescription);
+			return false;
+		}
+	}
+
+}

--- a/sapl-hamcrest/src/main/java/io/sapl/hamcrest/IsResourceMatching.java
+++ b/sapl-hamcrest/src/main/java/io/sapl/hamcrest/IsResourceMatching.java
@@ -1,0 +1,44 @@
+package io.sapl.hamcrest;
+
+import java.util.Objects;
+import java.util.function.Predicate;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.sapl.api.pdp.AuthorizationDecision;
+
+public class IsResourceMatching extends TypeSafeDiagnosingMatcher<AuthorizationDecision>  {
+	
+	private final Predicate<? super JsonNode> predicate;
+
+	public IsResourceMatching(Predicate<? super JsonNode> jsonPredicate) {
+		super(AuthorizationDecision.class);
+		this.predicate = Objects.requireNonNull(jsonPredicate);
+	}
+
+
+	@Override
+	public void describeTo(Description description) {
+		description.appendText("the decision has a resource matching the predicate");
+	}
+
+	@Override
+	protected boolean matchesSafely(AuthorizationDecision decision, Description mismatchDescription) {
+		if(decision.getResource().isEmpty())
+		{
+			mismatchDescription.appendText("decision didn't contain a resource");
+			return false;
+		}
+		
+		var json = decision.getResource().get();
+		if (this.predicate.test(json)) {
+			return true;
+		} else {
+			mismatchDescription.appendText("was resource that matches the predicate");
+			return false;
+		}
+	}
+}

--- a/sapl-hamcrest/src/main/java/io/sapl/hamcrest/IsVal.java
+++ b/sapl-hamcrest/src/main/java/io/sapl/hamcrest/IsVal.java
@@ -15,18 +15,6 @@
  */
 package io.sapl.hamcrest;
 
-import static com.spotify.hamcrest.jackson.IsJsonBoolean.jsonBoolean;
-import static com.spotify.hamcrest.jackson.IsJsonNull.jsonNull;
-import static com.spotify.hamcrest.jackson.IsJsonNumber.jsonBigDecimal;
-import static com.spotify.hamcrest.jackson.IsJsonNumber.jsonBigInteger;
-import static com.spotify.hamcrest.jackson.IsJsonNumber.jsonDouble;
-import static com.spotify.hamcrest.jackson.IsJsonNumber.jsonFloat;
-import static com.spotify.hamcrest.jackson.IsJsonNumber.jsonInt;
-import static com.spotify.hamcrest.jackson.IsJsonNumber.jsonLong;
-import static com.spotify.hamcrest.jackson.IsJsonText.jsonText;
-
-import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -50,58 +38,6 @@ public class IsVal extends TypeSafeDiagnosingMatcher<Val> {
 	public IsVal() {
 		super(Val.class);
 		this.jsonMatcher = Optional.empty();
-	}
-
-	public static Matcher<Val> val() {
-		return new IsVal();
-	}
-
-	public static Matcher<Val> val(String text) {
-		return new IsVal(jsonText(text));
-	}
-
-	public static Matcher<Val> val(int integer) {
-		return new IsVal(jsonInt(integer));
-	}
-
-	public static Matcher<Val> val(BigDecimal decimal) {
-		return new IsVal(jsonBigDecimal(decimal));
-	}
-
-	public static Matcher<Val> val(BigInteger bigInt) {
-		return new IsVal(jsonBigInteger(bigInt));
-	}
-
-	public static Matcher<Val> val(float floatValue) {
-		return new IsVal(jsonFloat(floatValue));
-	}
-
-	public static Matcher<Val> valNull() {
-		return new IsVal(jsonNull());
-	}
-
-	public static Matcher<Val> val(boolean bool) {
-		return new IsVal(jsonBoolean(bool));
-	}
-
-	public static Matcher<Val> valTrue() {
-		return val(true);
-	}
-
-	public static Matcher<Val> valFalse() {
-		return val(false);
-	}
-
-	public static Matcher<Val> val(double doubleValue) {
-		return new IsVal(jsonDouble(doubleValue));
-	}
-
-	public static Matcher<Val> val(long longValue) {
-		return new IsVal(jsonLong(longValue));
-	}
-
-	public static Matcher<Val> val(Matcher<? super JsonNode> jsonMatcher) {
-		return new IsVal(jsonMatcher);
 	}
 
 	@Override

--- a/sapl-hamcrest/src/main/java/io/sapl/hamcrest/IsValError.java
+++ b/sapl-hamcrest/src/main/java/io/sapl/hamcrest/IsValError.java
@@ -15,9 +15,6 @@
  */
 package io.sapl.hamcrest;
 
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsAnything.anything;
-
 import java.util.Objects;
 
 import org.hamcrest.Description;
@@ -33,18 +30,6 @@ public class IsValError extends TypeSafeDiagnosingMatcher<Val> {
 	public IsValError(Matcher<? super String> stringMatcher) {
 		super(Val.class);
 		this.stringMatcher = Objects.requireNonNull(stringMatcher);
-	}
-
-	public static Matcher<Val> valError() {
-		return new IsValError(is(anything()));
-	}
-
-	public static Matcher<Val> valError(String errorMessage) {
-		return new IsValError(is(errorMessage));
-	}
-
-	public static Matcher<Val> valError(Matcher<? super String> stringMatcher) {
-		return new IsValError(stringMatcher);
 	}
 
 	@Override

--- a/sapl-hamcrest/src/main/java/io/sapl/hamcrest/IsValUndefined.java
+++ b/sapl-hamcrest/src/main/java/io/sapl/hamcrest/IsValUndefined.java
@@ -16,7 +16,6 @@
 package io.sapl.hamcrest;
 
 import org.hamcrest.Description;
-import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 
 import io.sapl.api.interpreter.Val;
@@ -25,10 +24,6 @@ public class IsValUndefined extends TypeSafeDiagnosingMatcher<Val> {
 
 	public IsValUndefined() {
 		super(Val.class);
-	}
-
-	public static Matcher<Val> valUndefined() {
-		return new IsValUndefined();
 	}
 
 	@Override

--- a/sapl-hamcrest/src/main/java/io/sapl/hamcrest/Matchers.java
+++ b/sapl-hamcrest/src/main/java/io/sapl/hamcrest/Matchers.java
@@ -1,0 +1,185 @@
+package io.sapl.hamcrest;
+
+import static com.spotify.hamcrest.jackson.IsJsonBoolean.jsonBoolean;
+import static com.spotify.hamcrest.jackson.IsJsonNull.jsonNull;
+import static com.spotify.hamcrest.jackson.IsJsonNumber.jsonBigDecimal;
+import static com.spotify.hamcrest.jackson.IsJsonNumber.jsonBigInteger;
+import static com.spotify.hamcrest.jackson.IsJsonNumber.jsonDouble;
+import static com.spotify.hamcrest.jackson.IsJsonNumber.jsonFloat;
+import static com.spotify.hamcrest.jackson.IsJsonNumber.jsonInt;
+import static com.spotify.hamcrest.jackson.IsJsonNumber.jsonLong;
+import static com.spotify.hamcrest.jackson.IsJsonText.jsonText;
+import static com.spotify.hamcrest.jackson.JsonMatchers.jsonObject;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsAnything.anything;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.function.Predicate;
+
+import org.hamcrest.Matcher;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import io.sapl.api.interpreter.Val;
+import io.sapl.api.pdp.AuthorizationDecision;
+import io.sapl.api.pdp.Decision;
+
+public class Matchers {
+	public static Matcher<Val> val() {
+		return new IsVal();
+	}
+
+	public static Matcher<Val> val(String text) {
+		return new IsVal(jsonText(text));
+	}
+
+	public static Matcher<Val> val(int integer) {
+		return new IsVal(jsonInt(integer));
+	}
+
+	public static Matcher<Val> val(BigDecimal decimal) {
+		return new IsVal(jsonBigDecimal(decimal));
+	}
+
+	public static Matcher<Val> val(BigInteger bigInt) {
+		return new IsVal(jsonBigInteger(bigInt));
+	}
+
+	public static Matcher<Val> val(float floatValue) {
+		return new IsVal(jsonFloat(floatValue));
+	}
+
+	public static Matcher<Val> valNull() {
+		return new IsVal(jsonNull());
+	}
+
+	public static Matcher<Val> val(boolean bool) {
+		return new IsVal(jsonBoolean(bool));
+	}
+
+	public static Matcher<Val> valTrue() {
+		return val(true);
+	}
+
+	public static Matcher<Val> valFalse() {
+		return val(false);
+	}	
+	
+	public static Matcher<Val> anyVal() {
+		return new IsVal();
+	}
+
+	public static Matcher<Val> val(double doubleValue) {
+		return new IsVal(jsonDouble(doubleValue));
+	}
+
+	public static Matcher<Val> val(long longValue) {
+		return new IsVal(jsonLong(longValue));
+	}
+
+	public static Matcher<Val> val(Matcher<? super JsonNode> jsonMatcher) {
+		return new IsVal(jsonMatcher);
+	}
+	
+	public static Matcher<Val> valError() {
+		return new IsValError(is(anything()));
+	}
+
+	public static Matcher<Val> valError(String errorMessage) {
+		return new IsValError(is(errorMessage));
+	}
+
+	public static Matcher<Val> valError(Matcher<? super String> stringMatcher) {
+		return new IsValError(stringMatcher);
+	}
+
+	public static Matcher<Val> valUndefined() {
+		return new IsValUndefined();
+	}
+	
+	public static Matcher<AuthorizationDecision> isPermit() {
+		return new IsDecision(Decision.PERMIT);
+	}
+	
+	public static Matcher<AuthorizationDecision> isDeny() {
+		return new IsDecision(Decision.DENY);
+	}
+	
+	public static Matcher<AuthorizationDecision> isNotApplicable() {
+		return new IsDecision(Decision.NOT_APPLICABLE);
+	}
+	
+	public static Matcher<AuthorizationDecision> isIndeterminate() {
+		return new IsDecision(Decision.INDETERMINATE);
+	}
+	
+	public static Matcher<AuthorizationDecision> anyAuthDecision() {
+		return new IsDecision();
+	}
+	
+	public static Matcher<AuthorizationDecision> hasObligationMatching(Predicate<? super JsonNode> predicate) {
+		return new HasObligationMatching(predicate);
+	}
+	
+	public static Matcher<AuthorizationDecision> hasObligationContainingKeyValue(String key, Matcher<? super JsonNode> value) {
+		return new HasObligationContainingKeyValue(key, value);
+	}
+	
+	public static Matcher<AuthorizationDecision> hasObligationContainingKeyValue(String key, String value) {
+		return new HasObligationContainingKeyValue(key, jsonText(value));
+	}
+	
+	public static Matcher<AuthorizationDecision> hasObligationContainingKeyValue(String key) {
+		return new HasObligationContainingKeyValue(key);
+	}
+	
+	public static Matcher<AuthorizationDecision> hasObligation(ObjectNode node) {
+		return new HasObligation(jsonObject(node));
+	}
+	
+	public static Matcher<AuthorizationDecision> hasObligation(Matcher<? super JsonNode> matcher) {
+		return new HasObligation(matcher);
+	}
+		
+	public static Matcher<AuthorizationDecision> hasAdviceMatching(Predicate<? super JsonNode> predicate) {
+		return new HasAdviceMatching(predicate);
+	}
+
+	public static Matcher<AuthorizationDecision> hasAdviceContainingKeyValue(String key, Matcher<? super JsonNode> value) {
+		return new HasAdviceContainingKeyValue(key, value);
+	}
+	
+	public static Matcher<AuthorizationDecision> hasAdviceContainingKeyValue(String key, String value) {
+		return new HasAdviceContainingKeyValue(key, jsonText(value));
+	}
+	
+	public static Matcher<AuthorizationDecision> hasAdviceContainingKeyValue(String key) {
+		return new HasAdviceContainingKeyValue(key);
+	}
+	
+	public static Matcher<AuthorizationDecision> hasAdvice(ObjectNode node) {
+		return new HasAdvice(jsonObject(node));
+	}
+	
+	public static Matcher<AuthorizationDecision> hasAdvice(Matcher<? super JsonNode> matcher) {
+		return new HasAdvice(matcher);
+	}
+	
+	public static Matcher<AuthorizationDecision> isResource(ObjectNode node) {
+		return new IsResource(jsonObject(node));
+	}
+	
+	public static Matcher<AuthorizationDecision> isResource() {
+		return new IsResource();
+	}
+	
+	public static Matcher<AuthorizationDecision> anyResource() {
+		return new IsResource();
+	}
+	
+	public static Matcher<AuthorizationDecision> isResourceMatching(Predicate<? super JsonNode> predicate) {
+		return new IsResourceMatching(predicate);
+	}
+}

--- a/sapl-hamcrest/src/test/java/io/sapl/hamcrest/HasAdviceContainingKeyValueTest.java
+++ b/sapl-hamcrest/src/test/java/io/sapl/hamcrest/HasAdviceContainingKeyValueTest.java
@@ -1,0 +1,131 @@
+package io.sapl.hamcrest;
+
+import static com.spotify.hamcrest.jackson.JsonMatchers.jsonText;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Optional;
+
+import org.hamcrest.Matcher;
+import org.hamcrest.StringDescription;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import io.sapl.api.pdp.AuthorizationDecision;
+import io.sapl.api.pdp.Decision;
+
+class HasAdviceContainingKeyValueTest {
+	@Test
+	public void test() {
+		ObjectMapper mapper = new ObjectMapper();
+		ObjectNode advice = mapper.createObjectNode();
+		advice.put("foo", "bar");
+		advice.put("key", "value");
+		ArrayNode advices = mapper.createArrayNode();
+		advices.add(advice);
+
+		AuthorizationDecision dec = new AuthorizationDecision(Decision.PERMIT, Optional.empty(),
+				Optional.empty(), Optional.of(advices));
+
+		var sut = Matchers.hasAdviceContainingKeyValue("key", jsonText("value"));
+
+		assertThat(dec, is(sut));
+	}
+	
+	@Test
+	public void test_neg() {
+		ObjectMapper mapper = new ObjectMapper();
+		ObjectNode advice = mapper.createObjectNode();
+		advice.put("foo", "bar");
+		advice.put("key", "value");
+		ArrayNode advices = mapper.createArrayNode();
+		advices.add(advice);
+
+		AuthorizationDecision dec = new AuthorizationDecision(Decision.PERMIT, Optional.empty(),
+				Optional.empty(), Optional.of(advices));
+
+		var sut = Matchers.hasAdviceContainingKeyValue("xxx", jsonText("yyy"));
+
+		assertThat(dec, not(is(sut)));
+	}
+
+	@Test
+	public void test_nullDecision() {
+		var sut = Matchers.hasAdviceContainingKeyValue("key", jsonText("value"));
+
+		assertThat(null, not(is(sut)));
+	}
+
+	@Test
+	public void test_nullKey() {
+		assertThrows(NullPointerException.class, () ->  Matchers.hasAdviceContainingKeyValue(null, jsonText("value")));
+	}
+
+
+	@Test
+	public void test_nullValue() {
+		assertThrows(NullPointerException.class, () ->  Matchers.hasAdviceContainingKeyValue("key", (Matcher<JsonNode>)null));
+	}
+
+	@Test
+	public void test_emptyAdvice() {
+		AuthorizationDecision dec = new AuthorizationDecision(Decision.PERMIT, Optional.empty(), Optional.empty(), Optional.empty());
+
+		var sut = Matchers.hasAdviceContainingKeyValue("key", jsonText("value"));
+
+		assertThat(dec, not(is(sut)));
+	}
+	
+	@Test
+	public void test_emptyMatcher() {
+		ObjectMapper mapper = new ObjectMapper();
+		ObjectNode actualAdivce = mapper.createObjectNode();
+		actualAdivce.put("foo", "bar");
+		actualAdivce.put("key", "value");
+		ArrayNode actualAdivces = mapper.createArrayNode();
+		actualAdivces.add(actualAdivce);
+		AuthorizationDecision dec = new AuthorizationDecision(Decision.PERMIT, Optional.empty(), Optional.empty(), Optional.of(actualAdivces));
+
+		var sut = Matchers.hasAdviceContainingKeyValue("key");
+		
+		assertThat(dec, is(sut));
+	}
+	
+	@Test
+	public void test_StringValueMatcher() {
+		ObjectMapper mapper = new ObjectMapper();
+		ObjectNode actualAdivce = mapper.createObjectNode();
+		actualAdivce.put("foo", "bar");
+		actualAdivce.put("key", "value");
+		ArrayNode actualAdivces = mapper.createArrayNode();
+		actualAdivces.add(actualAdivce);
+		AuthorizationDecision dec = new AuthorizationDecision(Decision.PERMIT, Optional.empty(), Optional.empty(), Optional.of(actualAdivces));
+
+		var sut = Matchers.hasAdviceContainingKeyValue("key", "value");
+		
+		assertThat(dec, is(sut));
+	}
+	
+	@Test
+	void testDescriptionForMatcherEmptyMatcher() {
+		var sut = Matchers.hasAdviceContainingKeyValue("key");
+		final StringDescription description = new StringDescription();
+		sut.describeTo(description);
+		assertThat(description.toString(), is("the decision has an advice containing key key with any value"));
+	}
+	
+	@Test
+	void testDescriptionForMatcher() {
+		var sut = Matchers.hasAdviceContainingKeyValue("key", jsonText("value"));
+		final StringDescription description = new StringDescription();
+		sut.describeTo(description);
+		assertThat(description.toString(), is("the decision has an advice containing key key with a text node with value that is \"value\""));
+	}
+
+}

--- a/sapl-hamcrest/src/test/java/io/sapl/hamcrest/HasAdviceMatchingTest.java
+++ b/sapl-hamcrest/src/test/java/io/sapl/hamcrest/HasAdviceMatchingTest.java
@@ -1,0 +1,83 @@
+package io.sapl.hamcrest;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import org.hamcrest.StringDescription;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import io.sapl.api.pdp.AuthorizationDecision;
+import io.sapl.api.pdp.Decision;
+
+class HasAdviceMatchingTest {
+
+	@Test
+	public void test() {
+		Predicate<JsonNode> pred = (JsonNode jsonNode) -> jsonNode.has("foo");
+		var matcher = Matchers.hasAdviceMatching(pred);
+
+		ObjectMapper mapper = new ObjectMapper();
+		ObjectNode advice = mapper.createObjectNode();
+		advice.put("foo", "bar");
+		ArrayNode advices = mapper.createArrayNode();
+		advices.add(advice);
+		AuthorizationDecision dec = new AuthorizationDecision(Decision.PERMIT, Optional.empty(), Optional.empty(), Optional.of(advices));
+
+		
+		assertThat(dec, is(matcher));
+	}
+	
+	@Test
+	public void test_neg() {
+		Predicate<JsonNode> pred = (JsonNode jsonNode) -> jsonNode.has("xxx");
+		var matcher = Matchers.hasAdviceMatching(pred);
+
+		ObjectMapper mapper = new ObjectMapper();
+		ObjectNode advice = mapper.createObjectNode();
+		advice.put("foo", "bar");
+		ArrayNode advices = mapper.createArrayNode();
+		advices.add(advice);
+		AuthorizationDecision dec = new AuthorizationDecision(Decision.PERMIT, Optional.empty(), Optional.empty(), Optional.of(advices));
+
+		
+		assertThat(dec, not(is(matcher)));
+	}
+	
+	@Test
+	public void test_nullDecision() {
+		Predicate<JsonNode> pred = (JsonNode jsonNode) -> jsonNode.has("foo");
+		var matcher = Matchers.hasAdviceMatching(pred);
+		assertThat(null, not(is(matcher)));
+	}
+	
+	@Test
+	public void test_nullPredicate() {
+		assertThrows(NullPointerException.class, () ->  Matchers.hasAdviceMatching(null));
+	}
+	
+	@Test
+	public void test_emptyAdvices() {
+		Predicate<JsonNode> pred = (JsonNode jsonNode) -> jsonNode.has("foo");
+		var matcher = Matchers.hasAdviceMatching(pred);
+		assertThat(new AuthorizationDecision(Decision.PERMIT, Optional.empty(), Optional.empty(), Optional.empty()), not(is(matcher)));
+	}
+	
+	@Test
+	void testDescriptionForMatcher() {
+		Predicate<JsonNode> pred = (JsonNode jsonNode) -> jsonNode.has("foo");
+		var sut = Matchers.hasAdviceMatching(pred);
+		final StringDescription description = new StringDescription();
+		sut.describeTo(description);
+		assertThat(description.toString(), is("the decision has an advice matching the predicate"));
+	}
+}

--- a/sapl-hamcrest/src/test/java/io/sapl/hamcrest/HasAdviceTest.java
+++ b/sapl-hamcrest/src/test/java/io/sapl/hamcrest/HasAdviceTest.java
@@ -1,0 +1,124 @@
+package io.sapl.hamcrest;
+
+import static com.spotify.hamcrest.jackson.JsonMatchers.jsonText;
+import static io.sapl.hamcrest.Matchers.hasAdvice;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Optional;
+
+import org.hamcrest.StringDescription;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import io.sapl.api.pdp.AuthorizationDecision;
+import io.sapl.api.pdp.Decision;
+
+class HasAdviceTest {
+
+
+	@Test
+	public void test() {		
+		ObjectMapper mapper = new ObjectMapper();
+		ObjectNode advice = mapper.createObjectNode();
+		advice.put("foo", "bar");
+		ArrayNode advices = mapper.createArrayNode();
+		advices.add(advice);
+		AuthorizationDecision dec = new AuthorizationDecision(Decision.PERMIT, Optional.empty(), Optional.empty(), Optional.of(advices));
+	
+		var matcher = hasAdvice(advice);
+		
+		assertThat(dec, is(matcher));
+	}
+	
+	@Test
+	public void test_neg() {		
+		ObjectMapper mapper = new ObjectMapper();
+		ObjectNode advice = mapper.createObjectNode();
+		advice.put("foo", "bar");
+		ArrayNode advices = mapper.createArrayNode();
+		advices.add(advice);
+		
+		ObjectNode expectedadvice = mapper.createObjectNode();
+		expectedadvice.put("xxx", "xxx");
+		AuthorizationDecision dec = new AuthorizationDecision(Decision.PERMIT, Optional.empty(), Optional.empty(), Optional.of(advices));
+	
+		var matcher = hasAdvice(expectedadvice);
+		
+		assertThat(dec, not(is(matcher)));
+	}
+	
+	@Test
+	public void test_nullDecision() {
+		ObjectMapper mapper = new ObjectMapper();
+		ObjectNode advice = mapper.createObjectNode();
+		advice.put("foo", "bar");
+		var matcher = hasAdvice(advice);
+		assertThat(null, not(is(matcher)));
+	}
+	
+	@Test
+	public void test_emptyAdvice() {
+		ObjectMapper mapper = new ObjectMapper();
+		ObjectNode advice = mapper.createObjectNode();
+		advice.put("foo", "bar");
+		var matcher = hasAdvice(advice);
+		AuthorizationDecision dec = new AuthorizationDecision(Decision.PERMIT, Optional.empty(), Optional.empty(), Optional.empty());
+		assertThat(dec, not(is(matcher)));
+	}
+	
+	@Test
+	public void test_numberEqualTest() {
+		ObjectMapper mapper = new ObjectMapper();
+		ObjectNode expectedAdvice = mapper.createObjectNode();
+		expectedAdvice.put("foo", 1);
+		var matcher = hasAdvice(expectedAdvice);
+		ObjectNode actualAdvice = mapper.createObjectNode();
+		actualAdvice.put("foo", 1f);
+		ArrayNode actualAdvices = mapper.createArrayNode();
+		actualAdvices.add(actualAdvice);
+		AuthorizationDecision dec = new AuthorizationDecision(Decision.PERMIT, Optional.empty(), Optional.empty(), Optional.of(actualAdvices));
+		assertThat(dec, is(matcher));
+	}
+	
+	@Test
+	public void test_emptyMatcher() {
+		ObjectMapper mapper = new ObjectMapper();
+		ObjectNode actualAdvice = mapper.createObjectNode();
+		actualAdvice.put("foo", 1);
+		ArrayNode actualAdvices = mapper.createArrayNode();
+		actualAdvices.add(actualAdvice);
+		AuthorizationDecision dec = new AuthorizationDecision(Decision.PERMIT, Optional.empty(), Optional.empty(), Optional.of(actualAdvices));
+
+		var sut = new HasAdvice();
+		
+		assertThat(dec, is(sut));
+	}
+	
+	@Test
+	public void test_nullJsonNode() {
+		assertThrows(NullPointerException.class, () -> hasAdvice((ObjectNode)null));
+	}
+	
+	@Test
+	void testDescriptionForMatcherEmptyMatcher() {
+		var sut = new HasAdvice();
+		final StringDescription description = new StringDescription();
+		sut.describeTo(description);
+		assertThat(description.toString(), is("the decision has an advice equals any advice"));
+	}
+	
+	@Test
+	void testDescriptionForMatcher() {
+		var sut = hasAdvice(jsonText("value"));
+		final StringDescription description = new StringDescription();
+		sut.describeTo(description);
+		assertThat(description.toString(), is("the decision has an advice equals a text node with value that is \"value\""));
+	}
+
+}

--- a/sapl-hamcrest/src/test/java/io/sapl/hamcrest/HasObligationContainingKeyValueTest.java
+++ b/sapl-hamcrest/src/test/java/io/sapl/hamcrest/HasObligationContainingKeyValueTest.java
@@ -1,0 +1,114 @@
+package io.sapl.hamcrest;
+
+import static com.spotify.hamcrest.jackson.JsonMatchers.jsonText;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Optional;
+
+import org.hamcrest.Matcher;
+import org.hamcrest.StringDescription;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import io.sapl.api.pdp.AuthorizationDecision;
+import io.sapl.api.pdp.Decision;
+
+class HasObligationContainingKeyValueTest {
+
+	@Test
+	public void test() {
+		ObjectMapper mapper = new ObjectMapper();
+		ObjectNode obligation = mapper.createObjectNode();
+		obligation.put("foo", "bar");
+		obligation.put("key", "value");
+		ArrayNode obligations = mapper.createArrayNode();
+		obligations.add(obligation);
+
+		AuthorizationDecision dec = new AuthorizationDecision(Decision.PERMIT, Optional.empty(),
+				Optional.of(obligations), Optional.empty());
+
+		var sut = Matchers.hasObligationContainingKeyValue("key", jsonText("value"));
+
+		assertThat(dec, is(sut));
+	}
+
+	@Test
+	public void test_nullDecision() {
+		var sut = Matchers.hasObligationContainingKeyValue("key", jsonText("value"));
+
+		assertThat(null, not(is(sut)));
+	}
+
+	@Test
+	public void test_nullKey() {
+		assertThrows(NullPointerException.class, () ->  Matchers.hasObligationContainingKeyValue(null, jsonText("value")));
+	}
+
+
+	@Test
+	public void test_nullValue() {
+		assertThrows(NullPointerException.class, () ->  Matchers.hasObligationContainingKeyValue("key", (Matcher<JsonNode>)null));
+	}
+
+	@Test
+	public void test_emptyObligation() {
+		AuthorizationDecision dec = new AuthorizationDecision(Decision.PERMIT, Optional.empty(), Optional.empty(), Optional.empty());
+
+		var sut = Matchers.hasObligationContainingKeyValue("key", jsonText("value"));
+
+		assertThat(dec, not(is(sut)));
+	}
+	
+	@Test
+	public void test_emptyMatcher() {
+		ObjectMapper mapper = new ObjectMapper();
+		ObjectNode actualObligation = mapper.createObjectNode();
+		actualObligation.put("foo", "bar");
+		actualObligation.put("key", "value");
+		ArrayNode actualObligations = mapper.createArrayNode();
+		actualObligations.add(actualObligation);
+		AuthorizationDecision dec = new AuthorizationDecision(Decision.PERMIT, null, Optional.of(actualObligations), null);
+
+		var sut = Matchers.hasObligationContainingKeyValue("foo");
+		
+		assertThat(dec, is(sut));
+	}
+	
+	@Test
+	public void test_StringValueMatcher() {
+		ObjectMapper mapper = new ObjectMapper();
+		ObjectNode actualObligation = mapper.createObjectNode();
+		actualObligation.put("foo", "bar");
+		actualObligation.put("key", "value");
+		ArrayNode actualObligations = mapper.createArrayNode();
+		actualObligations.add(actualObligation);
+		AuthorizationDecision dec = new AuthorizationDecision(Decision.PERMIT, null, Optional.of(actualObligations), null);
+
+		var sut = Matchers.hasObligationContainingKeyValue("foo", "bar");
+		
+		assertThat(dec, is(sut));
+	}
+	
+	@Test
+	void testDescriptionForMatcherEmptyMatcher() {
+		var sut = Matchers.hasObligationContainingKeyValue("key");
+		final StringDescription description = new StringDescription();
+		sut.describeTo(description);
+		assertThat(description.toString(), is("the decision has an obligation containing key key with any value"));
+	}
+	
+	@Test
+	void testDescriptionForMatcher() {
+		var sut = Matchers.hasObligationContainingKeyValue("key", jsonText("value"));
+		final StringDescription description = new StringDescription();
+		sut.describeTo(description);
+		assertThat(description.toString(), is("the decision has an obligation containing key key with a text node with value that is \"value\""));
+	}
+}

--- a/sapl-hamcrest/src/test/java/io/sapl/hamcrest/HasObligationMatchingTest.java
+++ b/sapl-hamcrest/src/test/java/io/sapl/hamcrest/HasObligationMatchingTest.java
@@ -1,0 +1,83 @@
+package io.sapl.hamcrest;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import org.hamcrest.StringDescription;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import io.sapl.api.pdp.AuthorizationDecision;
+import io.sapl.api.pdp.Decision;
+
+class HasObligationMatchingTest {
+
+	@Test
+	public void test() {
+		Predicate<JsonNode> pred = (JsonNode jsonNode) -> jsonNode.has("foo");
+		var matcher = Matchers.hasObligationMatching(pred);
+
+		ObjectMapper mapper = new ObjectMapper();
+		ObjectNode obligation = mapper.createObjectNode();
+		obligation.put("foo", "bar");
+		ArrayNode obligations = mapper.createArrayNode();
+		obligations.add(obligation);
+		AuthorizationDecision dec = new AuthorizationDecision(Decision.PERMIT, Optional.empty(), Optional.of(obligations), Optional.empty());
+
+		
+		assertThat(dec, is(matcher));
+	}
+	
+	@Test
+	public void test_neg() {
+		Predicate<JsonNode> pred = (JsonNode jsonNode) -> jsonNode.has("xxx");
+		var matcher = Matchers.hasObligationMatching(pred);
+
+		ObjectMapper mapper = new ObjectMapper();
+		ObjectNode obligation = mapper.createObjectNode();
+		obligation.put("foo", "bar");
+		ArrayNode obligations = mapper.createArrayNode();
+		obligations.add(obligation);
+		AuthorizationDecision dec = new AuthorizationDecision(Decision.PERMIT, Optional.empty(), Optional.of(obligations), Optional.empty());
+
+		
+		assertThat(dec, not(is(matcher)));
+	}
+	
+	@Test
+	public void test_nullDecision() {
+		Predicate<JsonNode> pred = (JsonNode jsonNode) -> jsonNode.has("foo");
+		var matcher = Matchers.hasObligationMatching(pred);
+		assertThat(null, not(is(matcher)));
+	}
+	
+	@Test
+	public void test_nullPredicate() {
+		assertThrows(NullPointerException.class, () ->  Matchers.hasObligationMatching(null));
+	}
+	
+	@Test
+	public void test_emptyObligation() {
+		Predicate<JsonNode> pred = (JsonNode jsonNode) -> jsonNode.has("foo");
+		var matcher = Matchers.hasObligationMatching(pred);
+		assertThat(new AuthorizationDecision(Decision.PERMIT, Optional.empty(), Optional.empty(), Optional.empty()), not(is(matcher)));
+	}
+	
+	@Test
+	void testDescriptionForMatcher() {
+		Predicate<JsonNode> pred = (JsonNode jsonNode) -> jsonNode.has("foo");
+		var sut = Matchers.hasObligationMatching(pred);
+		final StringDescription description = new StringDescription();
+		sut.describeTo(description);
+		assertThat(description.toString(), is("the decision has an obligation matching the predicate"));
+	}
+}

--- a/sapl-hamcrest/src/test/java/io/sapl/hamcrest/HasObligationTest.java
+++ b/sapl-hamcrest/src/test/java/io/sapl/hamcrest/HasObligationTest.java
@@ -1,0 +1,125 @@
+package io.sapl.hamcrest;
+
+import static com.spotify.hamcrest.jackson.JsonMatchers.jsonText;
+import static io.sapl.hamcrest.Matchers.hasObligation;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Optional;
+
+import org.hamcrest.StringDescription;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import io.sapl.api.pdp.AuthorizationDecision;
+import io.sapl.api.pdp.Decision;
+
+class HasObligationTest {
+
+
+	@Test
+	public void test() {		
+		ObjectMapper mapper = new ObjectMapper();
+		ObjectNode obligation = mapper.createObjectNode();
+		obligation.put("foo", "bar");
+		ArrayNode obligations = mapper.createArrayNode();
+		obligations.add(obligation);
+		AuthorizationDecision dec = new AuthorizationDecision(Decision.PERMIT, Optional.empty(), Optional.of(obligations), Optional.empty());
+	
+		var sut = hasObligation(obligation);
+		
+		assertThat(dec, is(sut));
+	}
+	
+	@Test
+	public void test_neg() {		
+		ObjectMapper mapper = new ObjectMapper();
+		ObjectNode obligation = mapper.createObjectNode();
+		obligation.put("foo", "bar");
+		ArrayNode obligations = mapper.createArrayNode();
+		obligations.add(obligation);
+		
+		ObjectNode expectedObligation = mapper.createObjectNode();
+		expectedObligation.put("xxx", "xxx");
+		AuthorizationDecision dec = new AuthorizationDecision(Decision.PERMIT, Optional.empty(), Optional.of(obligations), Optional.empty());
+	
+		var sut = hasObligation(expectedObligation);
+		
+		assertThat(dec, not(is(sut)));
+	}
+	
+	@Test
+	public void test_nullDecision() {
+		ObjectMapper mapper = new ObjectMapper();
+		ObjectNode obligation = mapper.createObjectNode();
+		obligation.put("foo", "bar");
+		var sut = hasObligation(obligation);
+		assertThat(null, not(is(sut)));
+	}
+	
+	@Test
+	public void test_emptyObligation() {
+		ObjectMapper mapper = new ObjectMapper();
+		ObjectNode obligation = mapper.createObjectNode();
+		obligation.put("foo", "bar");
+		var sut = hasObligation(obligation);
+		AuthorizationDecision dec = new AuthorizationDecision(Decision.PERMIT, Optional.empty(), Optional.empty(), Optional.empty());
+		assertThat(dec, not(is(sut)));
+	}
+	
+	@Test
+	public void test_numberEqualTest() {
+		ObjectMapper mapper = new ObjectMapper();
+		ObjectNode expectedObligation = mapper.createObjectNode();
+		expectedObligation.put("foo", 1);
+		ObjectNode actualObligation = mapper.createObjectNode();
+		actualObligation.put("foo", 1f);
+		ArrayNode actualObligations = mapper.createArrayNode();
+		actualObligations.add(actualObligation);
+		AuthorizationDecision dec = new AuthorizationDecision(Decision.PERMIT, Optional.empty(), Optional.of(actualObligations), Optional.empty());
+
+		var sut = hasObligation(expectedObligation);
+		
+		assertThat(dec, is(sut));
+	}
+	
+	@Test
+	public void test_emptyMatcher() {
+		ObjectMapper mapper = new ObjectMapper();
+		ObjectNode actualObligation = mapper.createObjectNode();
+		actualObligation.put("foo", 1);
+		ArrayNode actualObligations = mapper.createArrayNode();
+		actualObligations.add(actualObligation);
+		AuthorizationDecision dec = new AuthorizationDecision(Decision.PERMIT, null, Optional.of(actualObligations), null);
+
+		var sut = new HasObligation();
+		
+		assertThat(dec, is(sut));
+	}
+	
+	@Test
+	public void test_nullJsonNode() {
+		assertThrows(NullPointerException.class, () -> hasObligation((ObjectNode)null));
+	}
+	
+	@Test
+	void testDescriptionForEmptyMatcher() {
+		var sut = new HasObligation();
+		final StringDescription description = new StringDescription();
+		sut.describeTo(description);
+		assertThat(description.toString(), is("the decision has an obligation equals any obligation"));
+	}
+	
+	@Test
+	void testDescriptionForMatcher() {
+		var sut = hasObligation(jsonText("value"));
+		final StringDescription description = new StringDescription();
+		sut.describeTo(description);
+		assertThat(description.toString(), is("the decision has an obligation equals a text node with value that is \"value\""));
+	}
+}

--- a/sapl-hamcrest/src/test/java/io/sapl/hamcrest/IsDecisionTest.java
+++ b/sapl-hamcrest/src/test/java/io/sapl/hamcrest/IsDecisionTest.java
@@ -1,0 +1,80 @@
+package io.sapl.hamcrest;
+
+import static io.sapl.hamcrest.Matchers.anyAuthDecision;
+import static io.sapl.hamcrest.Matchers.isDeny;
+import static io.sapl.hamcrest.Matchers.isIndeterminate;
+import static io.sapl.hamcrest.Matchers.isNotApplicable;
+import static io.sapl.hamcrest.Matchers.isPermit;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.hamcrest.StringDescription;
+import org.junit.jupiter.api.Test;
+
+import io.sapl.api.pdp.AuthorizationDecision;
+import io.sapl.api.pdp.Decision;
+
+class IsDecisionTest {
+
+	@Test
+	void testPermit() {
+		var sut = isPermit();
+		assertThat(new AuthorizationDecision(Decision.PERMIT), is(sut));
+		assertThat(new AuthorizationDecision(Decision.DENY), not(is(sut)));
+		assertThat(new AuthorizationDecision(Decision.NOT_APPLICABLE), not(is(sut)));
+		assertThat(new AuthorizationDecision(Decision.INDETERMINATE), not(is(sut)));
+	}
+	
+	@Test
+	void testDeny() {
+		var sut = isDeny();
+		assertThat(new AuthorizationDecision(Decision.PERMIT), not(is(sut)));
+		assertThat(new AuthorizationDecision(Decision.DENY), is(sut));
+		assertThat(new AuthorizationDecision(Decision.NOT_APPLICABLE), not(is(sut)));
+		assertThat(new AuthorizationDecision(Decision.INDETERMINATE), not(is(sut)));
+	}
+	
+	@Test
+	void testIsNotApplicable() {
+		var sut = isNotApplicable();
+		assertThat(new AuthorizationDecision(Decision.PERMIT), not(is(sut)));
+		assertThat(new AuthorizationDecision(Decision.DENY), not(is(sut)));
+		assertThat(new AuthorizationDecision(Decision.NOT_APPLICABLE), is(sut));
+		assertThat(new AuthorizationDecision(Decision.INDETERMINATE), not(is(sut)));
+	}
+	
+	@Test
+	void testIndeterminate() {
+		var sut = isIndeterminate();
+		assertThat(new AuthorizationDecision(Decision.PERMIT), not(is(sut)));
+		assertThat(new AuthorizationDecision(Decision.DENY), not(is(sut)));
+		assertThat(new AuthorizationDecision(Decision.NOT_APPLICABLE), not(is(sut)));
+		assertThat(new AuthorizationDecision(Decision.INDETERMINATE), is(sut));
+	}
+	
+	@Test
+	void testAnyDec() {
+		var sut = anyAuthDecision();
+		assertThat(new AuthorizationDecision(Decision.PERMIT), is(sut));
+		assertThat(new AuthorizationDecision(Decision.DENY), is(sut));
+		assertThat(new AuthorizationDecision(Decision.NOT_APPLICABLE), is(sut));
+		assertThat(new AuthorizationDecision(Decision.INDETERMINATE), is(sut));
+	}
+
+	@Test
+	void testDescriptionForEmptyConstructor() {
+		var sut = new IsDecision();
+		final StringDescription description = new StringDescription();
+		sut.describeTo(description);
+		assertThat(description.toString(), is("the decision is any decision"));
+	}
+	
+	@Test
+	void testDescriptionForDecisionConstructor() {
+		var sut = isPermit();
+		final StringDescription description = new StringDescription();
+		sut.describeTo(description);
+		assertThat(description.toString(), is("the decision is PERMIT"));
+	}
+}

--- a/sapl-hamcrest/src/test/java/io/sapl/hamcrest/IsResourceMatchingTest.java
+++ b/sapl-hamcrest/src/test/java/io/sapl/hamcrest/IsResourceMatchingTest.java
@@ -1,0 +1,79 @@
+package io.sapl.hamcrest;
+
+import static io.sapl.hamcrest.Matchers.isResourceMatching;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import org.hamcrest.StringDescription;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import io.sapl.api.pdp.AuthorizationDecision;
+import io.sapl.api.pdp.Decision;
+
+class IsResourceMatchingTest {
+
+	@Test
+	public void test() {
+		Predicate<JsonNode> pred = (JsonNode jsonNode) -> jsonNode.has("foo");
+		var sut = isResourceMatching(pred);
+
+		ObjectMapper mapper = new ObjectMapper();
+		ObjectNode resource = mapper.createObjectNode();
+		resource.put("foo", "bar");
+		AuthorizationDecision dec = new AuthorizationDecision(Decision.PERMIT, Optional.of(resource), null, null);
+		
+		assertThat(dec, is(sut));
+	}
+	
+	@Test
+	public void test_neg() {
+		Predicate<JsonNode> pred = (JsonNode jsonNode) -> jsonNode.has("xxx");
+		var sut = isResourceMatching(pred);
+
+		ObjectMapper mapper = new ObjectMapper();
+		ObjectNode resource = mapper.createObjectNode();
+		resource.put("foo", "bar");
+		AuthorizationDecision dec = new AuthorizationDecision(Decision.PERMIT, Optional.of(resource), null, null);
+		
+		assertThat(dec, not(is(sut)));
+	}
+	
+	@Test
+	public void test_nullDecision() {
+		Predicate<JsonNode> pred = (JsonNode jsonNode) -> jsonNode.has("foo");
+		var sut = isResourceMatching(pred);
+		assertThat(null, not(is(sut)));
+	}
+	
+	@Test
+	public void test_resourceEmpty() {
+		Predicate<JsonNode> pred = (JsonNode jsonNode) -> jsonNode.has("foo");
+		var sut = isResourceMatching(pred);
+		AuthorizationDecision dec = new AuthorizationDecision(Decision.PERMIT, Optional.empty(), null, null);
+		assertThat(dec, not(is(sut)));
+	}
+	
+	@Test
+	public void test_nullPredicate() {
+		assertThrows(NullPointerException.class, () -> isResourceMatching(null));
+	}
+	
+	@Test
+	void testDescriptionForMatcher() {
+		Predicate<JsonNode> pred = (JsonNode jsonNode) -> jsonNode.has("foo");
+		var sut = isResourceMatching(pred);
+		final StringDescription description = new StringDescription();
+		sut.describeTo(description);
+		assertThat(description.toString(), is("the decision has a resource matching the predicate"));
+	}
+
+}

--- a/sapl-hamcrest/src/test/java/io/sapl/hamcrest/IsResourceTest.java
+++ b/sapl-hamcrest/src/test/java/io/sapl/hamcrest/IsResourceTest.java
@@ -1,0 +1,96 @@
+package io.sapl.hamcrest;
+
+import static io.sapl.hamcrest.Matchers.anyResource;
+import static io.sapl.hamcrest.Matchers.isResource;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Optional;
+
+import org.hamcrest.StringDescription;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import io.sapl.api.pdp.AuthorizationDecision;
+import io.sapl.api.pdp.Decision;
+
+class IsResourceTest {
+
+	@Test
+	public void test() {		
+		ObjectMapper mapper = new ObjectMapper();
+		ObjectNode resource = mapper.createObjectNode();
+		resource.put("foo", "bar");
+		AuthorizationDecision dec = new AuthorizationDecision(Decision.PERMIT, Optional.of(resource), null, null);
+		
+		var sut = isResource(resource);
+		
+		assertThat(dec, is(sut));
+	}
+	
+	@Test
+	public void test_neg() {		
+		ObjectMapper mapper = new ObjectMapper();
+		ObjectNode expectedResource = mapper.createObjectNode();
+		expectedResource.put("foo", "bar");
+		ObjectNode actualResource = mapper.createObjectNode();
+		actualResource.put("xxx", "yyy");
+		AuthorizationDecision dec = new AuthorizationDecision(Decision.PERMIT, Optional.of(actualResource), null, null);
+		
+		var sut = isResource(expectedResource);
+		
+		assertThat(dec, not(is(sut)));
+	}
+	
+	@Test
+	public void test_nullDecision() {
+		ObjectMapper mapper = new ObjectMapper();
+		ObjectNode resource = mapper.createObjectNode();
+		resource.put("foo", "bar");
+		
+		var sut = isResource(resource);
+		
+		assertThat(null, not(is(sut)));
+	}
+	
+	@Test
+	public void test_emptyResource() {
+		ObjectMapper mapper = new ObjectMapper();
+		ObjectNode resource = mapper.createObjectNode();
+		resource.put("foo", "bar");
+		AuthorizationDecision dec = new AuthorizationDecision(Decision.PERMIT, Optional.empty(), null, null);
+		
+		var sut = isResource(resource);
+		
+		assertThat(dec, not(is(sut)));
+	}
+	
+	@Test
+	public void test_emptyMatcher() {
+		ObjectMapper mapper = new ObjectMapper();
+		ObjectNode resource = mapper.createObjectNode();
+		resource.put("foo", "bar");
+		AuthorizationDecision dec = new AuthorizationDecision(Decision.PERMIT, Optional.of(resource), null, null);
+
+		var sut = anyResource();
+		
+		assertThat(dec, is(sut));
+	}
+	
+	@Test
+	public void test_nullJsonNode() {
+		assertThrows(NullPointerException.class, () -> isResource(null));
+	}
+
+	@Test
+	void testDescriptionForMatcher() {
+		var sut = isResource();
+		final StringDescription description = new StringDescription();
+		sut.describeTo(description);
+		assertThat(description.toString(), is("a resource with any JsonNode"));
+	}	
+}

--- a/sapl-hamcrest/src/test/java/io/sapl/hamcrest/IsValErrorTest.java
+++ b/sapl-hamcrest/src/test/java/io/sapl/hamcrest/IsValErrorTest.java
@@ -1,6 +1,6 @@
 package io.sapl.hamcrest;
 
-import static io.sapl.hamcrest.IsValError.valError;
+import static io.sapl.hamcrest.Matchers.valError;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/sapl-hamcrest/src/test/java/io/sapl/hamcrest/IsValTest.java
+++ b/sapl-hamcrest/src/test/java/io/sapl/hamcrest/IsValTest.java
@@ -2,10 +2,11 @@ package io.sapl.hamcrest;
 
 import static com.spotify.hamcrest.jackson.JsonMatchers.jsonBoolean;
 import static com.spotify.hamcrest.jackson.JsonMatchers.jsonText;
-import static io.sapl.hamcrest.IsVal.val;
-import static io.sapl.hamcrest.IsVal.valFalse;
-import static io.sapl.hamcrest.IsVal.valNull;
-import static io.sapl.hamcrest.IsVal.valTrue;
+import static io.sapl.hamcrest.Matchers.anyVal;
+import static io.sapl.hamcrest.Matchers.val;
+import static io.sapl.hamcrest.Matchers.valFalse;
+import static io.sapl.hamcrest.Matchers.valNull;
+import static io.sapl.hamcrest.Matchers.valTrue;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -116,6 +117,16 @@ class IsValTest {
 	void testNull() {
 		var sut = valNull();
 		assertThat(Val.NULL, is(sut));
+	}
+	
+	@Test
+	void testAnyVal() {
+		var sut = anyVal();
+		assertThat(Val.NULL, is(sut));
+		assertThat(Val.of(1), is(sut));
+		assertThat(Val.FALSE, is(sut));
+		assertThat(Val.error(), not(is(sut)));
+		assertThat(Val.UNDEFINED, not(is(sut)));
 	}
 
 	@Test

--- a/sapl-hamcrest/src/test/java/io/sapl/hamcrest/IsValUndefinedTest.java
+++ b/sapl-hamcrest/src/test/java/io/sapl/hamcrest/IsValUndefinedTest.java
@@ -1,6 +1,6 @@
 package io.sapl.hamcrest;
 
-import static io.sapl.hamcrest.IsValUndefined.valUndefined;
+import static io.sapl.hamcrest.Matchers.valUndefined;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/sapl-hamcrest/src/test/java/io/sapl/hamcrest/MatchersTest.java
+++ b/sapl-hamcrest/src/test/java/io/sapl/hamcrest/MatchersTest.java
@@ -1,0 +1,13 @@
+package io.sapl.hamcrest;
+
+import org.junit.jupiter.api.Test;
+
+class MatchersTest {
+
+	@Test
+	void test() {
+		new Matchers();
+		//for 100% test coverage ;)
+	}
+
+}


### PR DESCRIPTION
This PR introduces two additions to the module "sapl-hamcrest".

1. Implementing Hamcrest Matchers for AuthorizationDecision

2. Move all static factory methods to single class "Matchers". So it's easier for developers to find all factory methods for matchers via import 
```
import static io.sapl.hamcrest.Matchers.*;
```
without searching examples or the codebase.
In addition the naming is consistent to similiar libaries like

```
import static org.hamcrest.CoreMatchers.*;
import static com.spotify.hamcrest.jackson.JsonMatchers.*;
...
```
