### PR TITLE
[sapl-server-lt] fix securityFilterChainLocal to allow authenticated connections only 

### DIFF
--- a/sapl-server-lt/src/main/java/io/sapl/server/lt/SecurityConfiguration.java
+++ b/sapl-server-lt/src/main/java/io/sapl/server/lt/SecurityConfiguration.java
@@ -39,8 +39,17 @@ public class SecurityConfiguration {
 	@Bean
 	@Profile("local")
 	public SecurityWebFilterChain securityFilterChainLocal(ServerHttpSecurity http) {
-		return http.csrf().disable().authorizeExchange().pathMatchers("/**").permitAll().anyExchange().authenticated()
-				.and().httpBasic().and().formLogin().disable().build();
+		return http
+				.csrf()
+					.disable()
+				.authorizeExchange()
+					// any other request requires the user to be authenticated
+					.anyExchange().authenticated()
+				.and()
+					.httpBasic()
+				.and()
+					.formLogin().disable()
+				.build();
 	}
 
 	@Bean


### PR DESCRIPTION
It seems that the "local" profile of sapl-server-lt is enabling basic authentication. Basic authentication is working but connections without basic authentications were allowed as well. Only connections with an incorrect basic authentication are rejected.
This fix enforces basic authentication for the "local" profile