### PR TITLE
Adding .devcontainer support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,32 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/java
+{
+	"name": "SAPL-Java",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/java:1-17-bookworm",
+	"features": {
+		"ghcr.io/devcontainers/features/java:1": {
+			"version": "none",
+			"installMaven": "true",
+			"installGradle": "false"
+		}
+	},
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "java -version",
+	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"streetsidesoftware.code-spell-checker",
+				"vscjava.vscode-java-pack",
+				"vscjava.vscode-lombok"
+			]
+		}
+	}
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}


### PR DESCRIPTION
With this PR we add the capability to use [.devcontainer](https://containers.dev/) in our repository.

It enables the build and development in a container and in GitHub Codespaces ([ref.](https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/adding-a-dev-container-configuration/introduction-to-dev-containers)).

Beyond the usage in the cloud environment GitHub Codespaces, Visual Studio Code ([ref.](https://code.visualstudio.com/docs/devcontainers/containers)) and IntelliJ ([ref.](https://www.jetbrains.com/help/idea/connect-to-devcontainer.html)) support the development in a local environment that has a docker runtime installed or can connect to a runtime.

Especially Visual Studio Code enables a seamless and fully functional integration of the devcontainer.

IntelliJ on the other hand currently lacks a fully featured integration, but the EAP already faces this issue ([ref.](https://blog.jetbrains.com/idea/2023/10/intellij-idea-2023-3-eap-6/))

Main benefit is that it does simplify the setup requirements, streamlines the workflow for setup and enables a consistent / repeatable environment for any developer.
