### PR TITLE
docs: Adding new documentation files 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Code owners are automatically requested for review when someone opens a pull request that modifies code that they own.
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# These owners will be the default owners for everything in the repo. Unless a later match takes precedence,
+# On opening a pull request @heutelbeck will be requested for review.
+*       @heutelbeck

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,66 @@
+name: "🐞 Bug Report"
+description: "Report a bug in this project."
+labels: ["bug"]
+
+body:
+
+  - type: markdown
+    attributes:
+      value: |
+        To expedite issue processing, please search open and closed issues before submitting a new one.
+        Please read our Code of Conduct and Contributing Guidelines at this repository.
+
+        **SECURITY RELATED?** Please view our [security policy](https://github.com/heutelbeck/sapl-policy-engine/blob/master/SECURITY.md).
+
+  - type: textarea
+    id: bug-report
+    attributes:
+      label: "What went wrong?"
+      description: "A clear and concise description of what the bug is."
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproducer
+    attributes:
+      label: "How to reproduce?"
+      description: "Provide reproducer, code examples or description for a minimal scenario to replicate the bug."
+    validations:
+      required: false
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: "What did you expect?"
+      description: "A clear and concise description of what you expected to happen."
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: "## Your environment"
+
+  - type: input
+    id: sapl-version
+    attributes:
+      label: "Which SAPL version is used?"
+      description: "e.g. 2.0.1 / 3.0.0-SNAPSHOT ({DATE}) ..."
+    validations:
+      required: false
+
+  - type: input
+    id: java-version
+    attributes:
+      label: "Which Java version is used?"
+      description: "e.g. OpenJDK 11.0.8 / Oracle JDK 1.8.0_261 ..."
+    validations:
+      required: false
+      
+  - type: input
+    id: operating-system
+    attributes:
+      label: "Which OS is running?"
+      description: "e.g. Ubuntu 5.4.0-26-generic x86_64 / Windows 1904 ..."
+    validations:
+      required: false
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/enhancement_request.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement_request.yml
@@ -1,0 +1,32 @@
+name: "🔧 Enhancement Request"
+description: "Request an enhancement for this project."
+labels: ["enhancement"]
+
+body:
+
+  - type: markdown
+    attributes:
+      value: |
+        To expedite issue processing, please search open and closed issues before submitting a new one.
+        Please read our Code of Conduct and Contributing Guidelines at this repository.
+
+  - type: textarea
+    attributes:
+      label: "Is your enhancement request related to a problem? Please describe."
+      description: "A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]"
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: "Describe the solution you'd like"
+      description: "A clear and concise description of what you want to happen."
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: "Describe alternatives you've considered"
+      description: "A clear and concise description of any alternative solutions or features you've considered."
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,32 @@
+name: "🚀 Feature Request"
+description: "Suggest an idea or possible new feature for this project."
+labels: ["feature"]
+
+body:
+
+  - type: markdown
+    attributes:
+      value: |
+        To expedite issue processing, please search open and closed issues before submitting a new one.
+        Please read our Code of Conduct and Contributing Guidelines at this repository.
+
+  - type: textarea
+    attributes:
+      label: "Is your feature request related to a problem? "
+      description: "A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]"
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: "Describe the solution you'd like."
+      description: "A clear and concise description of what you want to happen. "
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: "Describe alternatives you've considered."
+      description: "AA clear and concise description of any alternative solutions or features you've considered."
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/question_support.yml
+++ b/.github/ISSUE_TEMPLATE/question_support.yml
@@ -1,0 +1,20 @@
+name: "❓ Question or Support Request"
+description: "Questions and requests for support."
+labels: ["question"]
+
+body:
+
+  - type: markdown
+    attributes:
+      value: |
+        Before posting any questions or asking for support, first read the project's README.md file, the documentation, the website or other additional documentation that might be listed in the project's or module's README.md file.
+
+        To expedite issue processing, please search open and closed issues before submitting a new one.
+        Please read our Code of Conduct and Contributing Guidelines at this repository.
+
+  - type: textarea
+    attributes:
+      label: "Describe your question or ask for support."
+      description: "A clear and concise description of what your doubt is."
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,34 @@
+<!-- This PR fixes #NUMBER_OF_THE_ISSUE, and fixes #NUMBER_OF_THE_ISSUE -->
+
+## Description
+
+<!--
+Include a concise description of the changes (bug or feature), 
+it's impact, along with a summary of the solution
+-->
+
+
+## Checklist
+
+<!--
+Fill out and the perform the following checklist before publishing the PR for review.
+-->
+
+* [ ] I have updated the documentation accordingly.
+* [ ] I have added tests to cover my changes.
+* [ ] All new and existing tests passed.
+* [ ] My code follows the code style of this project.
+* [ ] I ran all checks which produced no new errors nor warnings for my changes.
+* [ ] I have checked to ensure there aren't other open Pull Requests for the same update/change.
+
+<!-- 📛📛📛
+All pull requests go through pipelines and careful peer review to ensure the quality of the code, but this does not exempt developers from delivering code that is good. 
+Write code to the best of your ability while considering best practices, guidelines, and requirements.
+
+If it fixes any current issue please let us know this way:
+Uncomment the comment above "description", then add your number of issues after the "#".
+Example: # **This pull request fixes #NUMBER_OF_THE_ISSUE issue**
+If there are multiple issues to be closed with the merge of this pull request
+please do it like so: **This pull request fixes #NUMBER_OF_THE_ISSUE, fixes #NUMBER_OF_THE_ISSUE and fixes #NUMBER_OF_THE_ISSUE issue**.
+For more information on closing issues using keywords, please check https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords#closing-multiple-issues
+📛📛📛 -->

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ node_modules/
 sapl-web/src/main/java/io/sapl/grammar/web/SAPLWebSetup.java
 sapl-web/src/main/java/io/sapl/grammar/web/SAPLWebModule.java
 sapl-ide/src/test/java/io/sapl/grammar/ide/contentassist/Schema_wo_variables.java
+.vscode

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,15 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, or religion.
+
+Examples of unacceptable behavior by participants include the use of sexual language or imagery, derogatory comments or personal attacks, trolling, public or private harassment, insults, or other unprofessional conduct.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. Project maintainers who do not follow the Code of Conduct may be removed from the project team.
+
+This code of conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one or more of the project maintainers.
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 1.1.0, available at https://www.contributor-covenant.org/version/1/1/0/code-of-conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,100 @@
+# Contributing
+
+This project welcomes any contributions and enforces the values of openness, usability, correctness, clean code and rigorous testing through the defined processes.
+
+You can contribute to this project by contributing to issues, discussions, and provide code changes.
+
+English is the mandated language for all communication and contributions.
+
+This project has adopted a [Code of Conduct](CODE_OF_CONDUCT.md) and it will be enforced in any communication.
+
+## Create an issue
+
+You can report bugs, create feature requests, propose enhancements or raise questions on the [issue page][issue-link].
+
+Choose and adhere to the provided templates and be as precise as possible to enable an easy evaluation of the issue.
+If you're interested in resolving your issue yourself, take a look at the possibility to create [code contributions](#propose-a-code-change).
+
+**Before creating any issue, please look up already closed or open issues!**
+
+### 🐞 Bug report
+
+A bug report should include details regarding any unforeseen or malfunctioning aspects of SAPL (please verify to the best of your ability that this pertains specifically to a dedicated issue with SAPL). Once the bug is reported, any project contributor can assess, engage in discussions, and contribute additional information to the corresponding issue.
+
+After a maintainer evaluates the bug, he or she will add a tag to categorize the bug and describe his examination result and the next steps that need to be taken.
+
+**Do not post bugs with security implications publicly and follow [this](#report-a-security-vulnerability).**
+
+### 🔧 Enhancement request
+
+An enhancement request is any kind of enhancement. It can be code, documentation, or anything else maintained in the repository. Once the request is posted, any project contributor can evaluate it, participate in discussions and contribute additional information to the issue.
+
+A decision can be made by consensus, ensuring stability and alignment with the direction of the project and module.
+
+### 🚀 Feature request
+
+A feature request is a request to add a new feature to the project. It should provide a new, unknown capability that is not already provided by this project. Once the request is posted, any project member can evaluate it, participate in discussions, and contribute additional information to the corresponding issue.
+
+The decision to add and support a new feature is done by the BDFL.
+
+### ❓ Question
+
+A question is an issue for requesting support on a specific topic, that the requestor can not answer on its own.
+Anyone is welcomed to help resolve this issue and the requestor or a maintainer will close this issue.
+
+## Report a security vulnerability
+
+If you find any security vulnerability please follow the process described [here](SECURITY.md).
+
+## Propose a code change
+
+With a code change you can actively improve the product itself. To ensure a high quality please follow the following guidelines and the enforced processes.
+
+Before writing code you might want to create an [issue](#create-an-issue) to get feedback before implementing.
+
+### Guidelines
+
+TODO - We need to provide and formalize more guidelines for styling and coding. No automatic tool will resolve all requirements.
+
+#### Pull requests
+
+All code contributions are expected to be reviewed and merged into the master branch via pull requests.
+
+To create a pull request for your code, you need to use a fork (except you are a maintainer). \
+Look up [here][github-fork-guide] how to create a fork and [here][github-fork-pr-guide] to create a pull request.
+
+**Apply the by default provided template to your pull request!**
+
+Once all required pipelines execute, tests pass and the changes are approved, the pull request will be merged by a maintainer.
+
+#### Code Style
+
+Maintaining a consistent code style is crucial for our project's readability.
+
+We enforce these standards automatically using [formatter-maven-plugin][eclipse-formatter-plugin] based on [Eclipse Code Formatter][eclipse-formatter-definition] configured in the [formatter.xml file](formatter.xml), which checks and ensures adherence to our guidelines.
+
+##### Rules
+
+Beyond the automatic enforcing of formatting by tools, we have style preferences that are described as the following rules.
+
+1. Use `var` instead of explicitly specifying the type whenever possible.
+2. Avoid starting interfaces with the letter `I`, e.g., `IFileProvider`.
+3. Avoid using the prefix `My` for variables, methods, and classes.
+4. Use the default scope for test classes and methods.
+5. End the names of test classes with `Tests`.
+6. Follow the pattern `whenSOMETHINGthenSOMETHING-ELSE` for naming test methods.
+7. Avoid using `@SuppressWarning`, except with explicit allowance from maintainers.
+8. If a file happens to differ in style from the guidelines, the existing style in that file takes precedence.
+
+#### Code coverage
+
+We strive to achieve a test coverage of at least 95%. Use the integrated tools of your IDE or our SonarCloud integration to check missing tests for branches / lines of code.
+
+<!-- MARKDOWN LINKS & IMAGES -->
+<!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->
+[issue-link]: https://github.com/heutelbeck/sapl-policy-engine/issues
+
+[eclipse-formatter-plugin]: https://code.revelc.net/formatter-maven-plugin/
+[eclipse-formatter-definition]: https://help.eclipse.org/latest/index.jsp?topic=%2Forg.eclipse.jdt.doc.user%2Freference%2Fpreferences%2Fjava%2Fcodestyle%2Fref-preferences-formatter.htm
+[github-fork-pr-guide]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork
+[github-fork-guide]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo

--- a/GOVERANCE.md
+++ b/GOVERANCE.md
@@ -1,0 +1,53 @@
+# Governance
+
+This document outlines the governance model for SAPL.
+
+👉 **Everyone must follow the [Code of Conduct (CoC)](CODE_OF_CONDUCT.md).**
+
+## Get Involved
+
+**Anything that supports SAPL is a valuable contribution!**
+
+All types of contribution are meaningful. This can include code changes, type fixes, Discord activity, and even posting about SAPL to your personal blog. No contribution is too small!
+
+Look up the [contribution file](CONTRIBUTING.md) for further information.
+
+## Roles
+
+We distinguish three roles in this project, which are organized as levels.
+This means that the higher the level, the more privileges and responsibilities are expected.
+
+### 1 - Contributor
+
+You qualify as a Contributor by making or attempting to make contributions, large or small, to the quality, success, or expansion of SAPL.
+
+#### Responsibilities
+
+This role does not require any extra responsibilities nor time commitment. We hope you stick around and keep participating in our community!
+
+If you're interested in contributing even more and becoming a **Maintainer**, you can explore some of those responsibilities in the [next section](#2---maintainer).
+
+### 2 - Maintainer
+
+A maintainer is responsible for evaluating contributions and providing in-depth knowledge and support to the project. Maintainers are selected by the BDFL of this project and are recognized members and contributors to this project.
+
+#### Privileges
+
+- Ability to push branches directly to the repository (personal forks no longer needed).
+- Ability to review PRs.
+- Ability to merge PRs.
+
+#### Responsibilities
+
+- Triage new issues.
+- Review pull requests.
+- Merge pull requests.
+- Merge your own pull requests (once reviewed and approved).
+
+### 3 - BDFL
+
+The project has a BDFL (Benevolent Dictator for Life), currently [@heutelbeck](https://github.com/heutelbeck).
+As Dictator, the BDFL has the authority to make all final decisions for the project and overrule anyone else.
+
+His primary responsibility is to set the strategic direction of the project.
+He also participates in the community and has the same responsibilities as the maintainers.

--- a/README.md
+++ b/README.md
@@ -1,62 +1,169 @@
-[![Build Status](https://github.com/heutelbeck/sapl-policy-engine/actions/workflows/build_master.yml/badge.svg)](https://github.com/heutelbeck/sapl-policy-engine/actions/workflows/build_master.yml)
-[![SonarCloud Status](https://sonarcloud.io/api/project_badges/measure?project=heutelbeck_sapl-policy-engine&metric=alert_status)](https://sonarcloud.io/dashboard?id=heutelbeck_sapl-policy-engine)
-[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=heutelbeck_sapl-policy-engine&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=heutelbeck_sapl-policy-engine)
-[![Maven Central](https://img.shields.io/maven-central/v/io.sapl/sapl-lang)](https://mvnrepository.com/artifact/io.sapl)
-[![Maven Snapshots](https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fs01.oss.sonatype.org%2Fcontent%2Frepositories%2Fsnapshots%2Fio%2Fsapl%2Fsapl-policy-engine%2Fmaven-metadata.xml)](https://s01.oss.sonatype.org/content/repositories/snapshots/io/sapl/)
-[![Discord](https://img.shields.io/discord/988472137306222654)](https://discord.gg/pRXEVWm3xM)
+<!-- PROJECT LOGO -->
+<br />
+<div align="center">
+  <a href="https://github.com/heutelbeck/sapl-policy-engine">
+    <img src="https://sapl.io/assets/logo-header-45.png" alt="Logo" >
+  </a>
 
-# The Streaming Attribute Policy Language (SAPL) Engine
+<h3 align="center">SAPL</h3>
 
-The Streaming Attribute Policy Language (SAPL) is a domain specific language for expressing access control policies following the attribute-based access control (ABAC) and attribute stream-based access control (ASBAC) patterns. Together with the its engine it allows to implement complex access control models. The SAPL Engine provides an implementation of SAPL, ABAC, and ASBAC to be used in application development. 
+  <p align="center">
+    The Streaming Attribute Policy Language and Engine
+    <br />
+    <a href="https://sapl.io/"><strong>Explore our website »</strong></a>
+    <br />
+    <br />
+    <a href="https://playground.sapl.io/">Playground</a>
+    ·
+    <a href="https://github.com/heutelbeck/sapl-demos">Demos</a>
+    ·
+    <a href="https://github.com/heutelbeck/sapl-policy-engine/issues">Report an issue</a>
+    ·
+    <a href="https://github.com/heutelbeck/sapl-policy-engine/issues">Discord</a>
+  </p>
+</div>
 
-## Maven Dependencies
+<!-- PROJECT SHIELDS -->
+[![Build Status][build-status-shield]][build-status-url]
+[![SonarCloud Status][sonarcloud-status-shield]][sonarcloud-status-url]
+[![Security Rating][security-rating-shield]][security-rating-url]
+[![Maven Central][maven-central-shield]][maven-central-url]
+[![Maven Snapshots][snapshot-shield]][snapshot-url]
 
-### Add the Maven Central snapshot repository to your `pom.xml`, if you want to use SNAPSHOT versions of the engine:
+
+<!-- ABOUT THE PROJECT -->
+## About The Project
+
+The reactive open source engine for adding Attribute-Based Access Control (ABAC) to your Java applications, supporting attribute streams for efficient interactive real-time access control.
+
+SAPL is a powerful policy language and engine for implementing ABAC. It comes with development tools for testing, authorization servers and authoring tools. Framework integrations are available for Spring, Axon and Vaadin to provide flexible policy enforcement points (PEPs) in your application.
+
+For an explanation, overview and documentation about the SAPL project look up our [website][website-url].
+
+<!-- GETTING STARTED -->
+## Getting Started
+
+To get started with integrating SAPL into your Java application, add the following reference to your build tool project definition.
+
+**We recommend to use the [SNAPSHOT](#snapshots) version as the latest stable version is outdated.**
+
+**Maven**
 
 ```xml
-  <repositories>
-    <repository>
-      <id>ossrh</id>
-      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
+<dependency>
+  <groupId>io.sapl</groupId>
+  <artifactId>sapl-pdp-embedded</artifactId>
+  <version>2.0.1</version>
+</dependency>
 ```
 
-### SAPL requires Java 17 or later
+**Gradle**
 
-```xml
-  <properties>
-    <java.version>17</java.version>
-    <maven.compiler.source>${java.version}</maven.compiler.source>
-    <maven.compiler.target>${java.version}</maven.compiler.target>
-  </properties>
+```gradle
+dependencies {
+  implementation 'io.sapl:sapl-pdp-embedded:2.0.1'
+}
 ```
 
-### Add a SAPL dependency to your application. When using Maven you can add the following dependencies to your project's `pom.xml`:
+This enables you to use the interface `PolicyDecisionPoint` to decide about requests.
+
+Want to integrate and understand the full scale of capabilities of SAPL? Visit our [website][website-url].
+
+Want to see examples for integration? View our dedicated [demos](#want-to-integrate-sapl).
+
+Feeling experimental? Use our [snapshots](#snapshots) for the newest development state!
+
+<!-- DEMOS -->
+## Want to integrate SAPL?
+
+SAPL supports different integration scenarios, which are partially described on our [website][website-url].
+
+If you want to see examples, view our [demo repository][demos-url] to give you a gist about how you could integrate SAPL.
+
+<!-- CONTRIBUTING -->
+## Want to contribute to SAPL?
+
+Any contributions you make are **greatly appreciated**.
+
+See our [Contribution document](CONTRIBUTING.md) for more detailed information on how to contribute.
+
+<!-- SECURITY -->
+## Found a vulnerability?
+
+The project is commited to identifying and eliminating any potential weaknesses in its security.
+
+See our [Security document](SECURITY.md) for more detailed information on how to report vulnerabilities.
+
+<!-- SNAPSHOTS REFERENCE -->
+## Snapshots
+
+This projects provides snapshots of the newest development state to enable testing and integration.
+
+**Be careful when using snapshots as they may be broken!**
+
+To add snapshot references to your project add the following references to your build tool project definition.
+
+**Maven**
 
 ```xml
+<repositories>
+  <repository>
+    <id>ossrh</id>
+    <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+    <snapshots>
+      <enabled>true</enabled>
+    </snapshots>
+  </repository>
+</repositories>
+...
+<dependencies>
   <dependency>
     <groupId>io.sapl</groupId>
-    <artifactId>sapl-pdp-embedded</artifactId>
+    <artifactId>sapl-{package}</artifactId>
     <version>3.0.0-SNAPSHOT</version>
   </dependency>
+</dependencies>
 ```
 
-### If you plan to use more SAPL dependencies, a useful bill of materials POM is offered, centralizing the dependency management for SAPL artifacts:
+**Gradle**
 
-```xml
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>io.sapl</groupId>
-        <artifactId>sapl-bom</artifactId>
-        <version>3.0.0-SNAPSHOT</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
+```gradle
+repositories {
+  maven {
+    url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots")
+  }
+}
+
+dependencies {
+  implementation 'io.sapl:sapl-{package}3.0.0-SNAPSHOT'
+}
 ```
+
+**You need to replace `{package}` with the designated project!**
+
+
+<!-- CODE OF CONDUCT -->
+## Code of Conduct
+
+This project has adopted a [Code of Conduct](CODE_OF_CONDUCT.md) and it will be enforced in any communication.
+
+<!-- LICENSE -->
+## License
+
+Distributed under the Apache 2.0 License. See [LICENSE.md](./LICENSE.md) for more information.
+
+<!-- MARKDOWN LINKS & IMAGES -->
+<!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->
+[build-status-shield]: https://github.com/heutelbeck/sapl-policy-engine/actions/workflows/build_master.yml/badge.svg
+[build-status-url]: https://github.com/heutelbeck/sapl-policy-engine/actions/workflows/build_master.yml
+[sonarcloud-status-shield]: https://sonarcloud.io/api/project_badges/measure?project=heutelbeck_sapl-policy-engine&metric=alert_status
+[sonarcloud-status-url]: https://sonarcloud.io/dashboard?id=heutelbeck_sapl-policy-engine
+[security-rating-shield]: https://sonarcloud.io/api/project_badges/measure?project=heutelbeck_sapl-policy-engine&metric=security_rating
+[security-rating-url]: https://sonarcloud.io/summary/new_code?id=heutelbeck_sapl-policy-engine
+[maven-central-shield]: https://img.shields.io/maven-central/v/io.sapl/sapl-lang
+[maven-central-url]: https://mvnrepository.com/artifact/io.sapl
+[snapshot-shield]: https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fs01.oss.sonatype.org%2Fcontent%2Frepositories%2Fsnapshots%2Fio%2Fsapl%2Fsapl-policy-engine%2Fmaven-metadata.xml
+[snapshot-url]: https://s01.oss.sonatype.org/content/repositories/snapshots/io/sapl
+
+[website-url]: https://sapl.io
+[demos-url]: https://github.com/heutelbeck/sapl-demos

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,22 @@
+# Security
+
+This project takes security vulnerabilities in SAPL seriously.
+We appreciate your efforts to responsibly disclose your findings, and will ensure to acknowledge your contributions.
+
+## Supported Versions
+
+We do not support old versions, all bug/feature/security updates will be released in the next planned release.
+
+| Version     | Supported          |
+|-------------|--------------------|
+| LATEST only | :white_check_mark: |
+
+## Reporting Security Issues
+
+**Please do not report security vulnerabilities through public issues.**
+
+Instead please use the [advisory feature](https://github.com/heutelbeck/sapl-policy-engine/security/advisories) to report security vulnerabilities. This enables us to triage and resolve critical vulnerabilities before disclosing to the public.
+
+If you're unable to use this feature you can send a mail to <dominic@heutelbeck.com>.
+
+We strive to acknowledge each report in less than 5 business days. The time it takes to resolve a report depends on the specifics of the vulnerability.


### PR DESCRIPTION
**Integrates #52 and requires resolve before closing.**

This commit adds new references and guidelines for using this repository.

Integration of this commit requires many adjustments of the
GitHub repository to be compliant with the requirements.

Further this can only be the first step, as it just provides documentation,
but lacks in depth guidelines and moves many responsibilities to the
website, which is currently not completely ready.

These changes will resolve requirements of  [OpenSSF Best Practices](https://www.bestpractices.dev/en) 
by either documenting or implementing it.

- https://github.com/FTKeV/fapra-2023/issues/1
- https://github.com/FTKeV/fapra-2023/issues/4
- https://github.com/FTKeV/fapra-2023/issues/5
- https://github.com/FTKeV/fapra-2023/issues/6
- https://github.com/FTKeV/fapra-2023/issues/18
- https://github.com/FTKeV/fapra-2023/issues/19 (partially due to bus factor)
- https://github.com/FTKeV/fapra-2023/issues/20 (partially due to requirements after achievement of standard)
- https://github.com/FTKeV/fapra-2023/issues/24
- https://github.com/FTKeV/fapra-2023/issues/25
- https://github.com/FTKeV/fapra-2023/issues/42 (partially, we need to define code guidelines in detail to fulfill)

@heutelbeck this is just the first proposition for alignment and discussion about
how the documents should be designed.

What do you think?