### PR TITLE
Update links in READMEs to point to latest SAPL documentation

### DIFF
--- a/sapl-documentation/README.md
+++ b/sapl-documentation/README.md
@@ -1,3 +1,3 @@
 # SAPL Documentation
 
-Read the documentation here: <https://sapl.io/docs/2.1.0-SNAPSHOT/sapl-reference.html>
+Read the documentation here: <https://sapl.io/docs/latest/sapl-reference.html>

--- a/sapl-maven-plugin/README.md
+++ b/sapl-maven-plugin/README.md
@@ -22,37 +22,3 @@ Contains POJO models used in the SAPL Maven Plugin.
 **report**:
 Contains all code necessary to generate the various reports. 
 In this package, the `GenericCoverageReporter.java` generates a generic coverage report format. A subpackage is defined for every supported report format, which produces the specific report from the generic coverage report format.
-
-## Report package
-### sonar: Sonar Generic Coverage Report for SAPL
-
-SonarQube and SonarCloud define a generic XSD to enable [generic coverage reports](https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/test-coverage/generic-test-data/).
-
-This reporter generates a file usually located at target/sapl-coverage/sonar/sonar-generic-coverage.xml.
-
-To tell SonarQube or SonarCloud to collect this generic coverage report you have to set the parameter 
-	
-	-Dsonar.coverageReportPaths=target/sapl-coverage/sonar/sonar-generic-coverage.xml
-
-
-In this file every SAPL policy is referenced via its path in the src/main/resources directory.
-
-By default, the Sonar Maven Plugin only collects files at the paths "pom.xml,src/main/java". This is the default setting for the "sonar.sources" parameter.
-
-To collect the SAPL policies in the src/main/resources directory you have to specify some additional parameters at Sonar Maven Plugin execution time.
-
-	-Dsonar.sources=. -Dsonar.inclusions=pom.xml,src/main/java/**,src/main/resources/**
-
-SonarQube and SonarCloud currently do not support generic coverage reports for unknown languages like SAPL. To use the report in your SonarQube/SonarCloud analysis, a workaround is needed. See the [SAPL documentation](https://sapl.io/docs/2.0.1/sapl-reference.html#code-coverage-reports-via-the-sapl-maven-plugin) for details.
-
-### sonar.model: Generate Models from Sonar Generic Coverage XSD Schema
-
-1. Get schema from [here](https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/test-coverage/generic-test-data/).
-
-2. Modify sonar-generic-coverage.xsd to bound schema:
-```
-    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-    <xs:schema version="1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema">
-```
-
-3. Generate via `xjc -d sonar -p io.sapl.test.mavenplugin.model.sonar sonar-generic-coverage.xsd`

--- a/sapl-maven-plugin/README.md
+++ b/sapl-maven-plugin/README.md
@@ -2,7 +2,7 @@
 
 This module contains the source code of the SAPL Maven Plugin.
 
-For a detailed description of the usage and the available parameters for the SAPL Maven Plugin, consult the [SAPL Docs](https://sapl.io/docs/2.0.1/sapl-reference.html#code-coverage-reports-via-the-sapl-maven-plugin).
+For a detailed description of the usage and the available parameters for the SAPL Maven Plugin, consult the [SAPL Docs](https://sapl.io/docs/latest/sapl-reference.html#code-coverage-reports-via-the-sapl-maven-plugin).
 
 ## Top-level packages
 

--- a/sapl-test/README.md
+++ b/sapl-test/README.md
@@ -2,7 +2,7 @@
 
 This module contains the SAPL Test Framework for defining unit and policy integration tests of your SAPL policies.
 
-For a detailed explanation of the features, consult the [SAPL Docs](https://sapl.io/docs/sapl-reference.html#testing-your-sapl-policies).
+For a detailed explanation of the features, consult the [SAPL Docs](https://sapl.io/docs/latest/sapl-reference.html#testing-sapl-policies).
 
 ## Top-level packages
 

--- a/sapl-webflux-endpoint/README.md
+++ b/sapl-webflux-endpoint/README.md
@@ -2,4 +2,4 @@
 
 This module contains a Webflux-based controller for wrapping a PDP and exposing it through the web API using Server-Sent Events.
 
-[API specifications](https://sapl.io/docs/sapl-reference.html#http-server-sent-events-api)
+[API specifications](https://sapl.io/docs/latest/sapl-reference.html#http-server-sent-events-api)


### PR DESCRIPTION
Updates and fixes some links to the SAPL documentation in README files. Links will now point to the latest doc version, so they do not have to be updated individually with a new release or snapshot.