### PR TITLE
Address CVE-2023-34054 by update reactor netty to 1.0.40

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
 		<spotify.hamcrest.version>1.3.2</spotify.hamcrest.version>
 		<springboot.version>3.2.0</springboot.version>
 		<vaadin.version>24.2.6</vaadin.version>
-		<reactornetty.version>1.0.23</reactornetty.version>
+		<reactornetty.version>1.0.40</reactornetty.version>
 		<rsocket.version>1.1.4</rsocket.version>
 		<assertj.version>3.24.2</assertj.version>
 		<license-maven-plugin.version>4.2</license-maven-plugin.version>


### PR DESCRIPTION
With this PR we address the [CVE-2023-34054: Reactor Netty HTTP Server Metrics DoS Vulnerability](https://spring.io/security/cve-2023-34054)