### PR TITLE
adding warning as error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -247,6 +247,8 @@
 						<compilerArgs>
 							<arg>-parameters</arg>
 						</compilerArgs>
+						<failOnError>true</failOnError>
+						<failOnWarning>true</failOnWarning>
 					</configuration>
 				</plugin>
 				<plugin>


### PR DESCRIPTION
## Description

As we strive to achieve the highest OSSF Score, we should treat warnings as errors.

But this would require us to heavily invest and resolve any current warning.

This is just a draft to show how we could activate this feature and open the discussion
for further steps.

See https://github.com/FTKeV/fapra-2023/issues/10, https://github.com/FTKeV/fapra-2023/issues/32