### PR TITLE
include templates directory in sonar scanning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,7 @@
 		<failsafe.version>3.1.2</failsafe.version>
 		<docker-registry-url>ghcr.io/heutelbeck</docker-registry-url>
 		<sonar.exclusions>**/xtext-gen/**/*,**/xtend-gen/**/*,**/emf-gen/**/*</sonar.exclusions>
+		<sonar.sources>src/main/java,src/main/resources/html/templates</sonar.sources>
 		<argLine/>
 	</properties>
 


### PR DESCRIPTION
Hallo Dominic.

Behandelt werden soll diese Warnung bei SonarCloud: "Thymeleaf templates are not indexed : you may want to add “src/main/resources” in the scanned files"

Gelöst entsprechend der Doku:
https://docs.sonarsource.com/sonarcloud/advanced-setup/languages/java/#analyzing-jsp-and-thymeleaf-for-xss-vulnerabilities

Ich habe es jedoch nicht selbst testen können.