### PR TITLE
fix issue with resolving of resources path based on OS

### DIFF
--- a/sapl-pdp-embedded/src/test/java/io/sapl/pdp/config/resources/ResourcesVariablesAndCombinatorSourceTests.java
+++ b/sapl-pdp-embedded/src/test/java/io/sapl/pdp/config/resources/ResourcesVariablesAndCombinatorSourceTests.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.file.Path;
 
 import org.junit.jupiter.api.Test;
@@ -107,7 +108,7 @@ class ResourcesVariablesAndCombinatorSourceTests {
 
     @Test
     void ifExecutedInJarAndConfigFileBroken_thenPropagateException(@TempDir(cleanup = CleanupMode.ALWAYS) Path tempDir)
-            throws IOException {
+            throws IOException, URISyntaxException {
         var url = JarCreator.createBrokenPoliciesInJar("!/policies", tempDir);
         try (MockedStatic<JarUtil> mock = mockStatic(JarUtil.class, CALLS_REAL_METHODS)) {
             mock.when(() -> JarUtil.inferUrlOfResourcesPath(any(), any())).thenReturn(url);

--- a/sapl-pdp-embedded/src/test/java/io/sapl/prp/resources/ResourcesPrpUpdateEventSourceTests.java
+++ b/sapl-pdp-embedded/src/test/java/io/sapl/prp/resources/ResourcesPrpUpdateEventSourceTests.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URISyntaxException;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.file.Path;
@@ -95,7 +96,7 @@ class ResourcesPrpUpdateEventSourceTests {
 
     @Test
     void ifExecutedInJar_thenLoadDocumentsFromJar(@TempDir(cleanup = CleanupMode.ALWAYS) Path tempDir)
-            throws InitializationException, IOException {
+            throws InitializationException, IOException, URISyntaxException {
         var url = JarCreator.createPoliciesInJar("!/policies", tempDir);
         try (MockedStatic<JarUtil> mock = mockStatic(JarUtil.class, CALLS_REAL_METHODS)) {
             mock.when(() -> JarUtil.inferUrlOfResourcesPath(any(), any())).thenReturn(url);

--- a/sapl-pdp-embedded/src/test/java/io/sapl/util/JarCreator.java
+++ b/sapl-pdp-embedded/src/test/java/io/sapl/util/JarCreator.java
@@ -46,11 +46,8 @@ public class JarCreator {
                 tempDir);
     }
 
-    private static void createJar(String jarFilePath, String[] sourcePaths) throws IOException {
-        try (var fos = new FileOutputStream(jarFilePath);
-                var bos = new BufferedOutputStream(fos);
-                var jos = new JarOutputStream(bos)) {
-
+    private static void createJar(Path jarFilePath, String[] sourcePaths) throws IOException {
+        try (var jos = new JarOutputStream(Files.newOutputStream(jarFilePath))) {
             for (String sourcePath : sourcePaths) {
                 var source = Path.of(sourcePath);
                 addFileToJar(source, source, jos);
@@ -60,18 +57,15 @@ public class JarCreator {
 
     private static URL createJarFromResource(String jarName, String resourcePath, String jarFolderReference,
             Path tempDir) throws IOException {
-        var path = tempDir + "/" + jarName;
+        var path = tempDir.resolve(jarName);
         JarCreator.createJar(path, new String[] { JarCreator.class.getResource(resourcePath).getPath() });
-        return new URL("jar:" + Paths.get(path).toUri().toURL() + jarFolderReference);
+        return new URL("jar:" + path.toUri().toURL() + jarFolderReference);
     }
 
     private static void addFileToJar(Path root, Path source, JarOutputStream jos) throws IOException {
         var relativePath = root.toUri().relativize(source.toUri()).getPath();
 
         if (Files.isDirectory(source)) {
-            if (!relativePath.isEmpty() && !relativePath.endsWith("/")) {
-                relativePath += "/";
-            }
             var jarEntry = new JarEntry(relativePath);
             jos.putNextEntry(jarEntry);
             jos.closeEntry();

--- a/sapl-pdp-embedded/src/test/java/io/sapl/util/JarCreator.java
+++ b/sapl-pdp-embedded/src/test/java/io/sapl/util/JarCreator.java
@@ -17,8 +17,6 @@
  */
 package io.sapl.util;
 
-import java.io.BufferedOutputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URI;
@@ -26,7 +24,6 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 import java.util.stream.Stream;
@@ -39,11 +36,13 @@ import lombok.experimental.UtilityClass;
 @UtilityClass
 public class JarCreator {
 
-    public static URL createPoliciesInJar(String jarFolderReference, Path tempDir) throws IOException {
+    public static URL createPoliciesInJar(String jarFolderReference, Path tempDir)
+            throws IOException, URISyntaxException {
         return createJarFromResource("policies_in_jar.jar", "/setups/policies_in_jar", jarFolderReference, tempDir);
     }
 
-    public static URL createBrokenPoliciesInJar(String jarFolderReference, Path tempDir) throws IOException {
+    public static URL createBrokenPoliciesInJar(String jarFolderReference, Path tempDir)
+            throws IOException, URISyntaxException {
         return createJarFromResource("broken_policies_in_jar.jar", "/setups/broken_config", jarFolderReference,
                 tempDir);
     }
@@ -58,17 +57,9 @@ public class JarCreator {
     }
 
     private static URL createJarFromResource(String jarName, String resourcePath, String jarFolderReference,
-            Path tempDir) throws IOException {
+            Path tempDir) throws IOException, URISyntaxException {
         var path = tempDir.resolve(jarName);
-        try {
-            JarCreator.createJar(path, new URI[] { JarCreator.class.getResource(resourcePath).toURI() });
-        } catch (IOException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
-        } catch (URISyntaxException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
-        }
+        JarCreator.createJar(path, new URI[] { JarCreator.class.getResource(resourcePath).toURI() });
         return new URL("jar:" + path.toUri().toURL() + jarFolderReference);
     }
 

--- a/sapl-pdp-embedded/src/test/java/io/sapl/util/JarCreator.java
+++ b/sapl-pdp-embedded/src/test/java/io/sapl/util/JarCreator.java
@@ -21,6 +21,8 @@ import java.io.BufferedOutputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -46,9 +48,9 @@ public class JarCreator {
                 tempDir);
     }
 
-    private static void createJar(Path jarFilePath, String[] sourcePaths) throws IOException {
+    private static void createJar(Path jarFilePath, URI[] sourcePaths) throws IOException {
         try (var jos = new JarOutputStream(Files.newOutputStream(jarFilePath))) {
-            for (String sourcePath : sourcePaths) {
+            for (var sourcePath : sourcePaths) {
                 var source = Path.of(sourcePath);
                 addFileToJar(source, source, jos);
             }
@@ -58,7 +60,15 @@ public class JarCreator {
     private static URL createJarFromResource(String jarName, String resourcePath, String jarFolderReference,
             Path tempDir) throws IOException {
         var path = tempDir.resolve(jarName);
-        JarCreator.createJar(path, new String[] { JarCreator.class.getResource(resourcePath).getPath() });
+        try {
+            JarCreator.createJar(path, new URI[] { JarCreator.class.getResource(resourcePath).toURI() });
+        } catch (IOException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        } catch (URISyntaxException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
         return new URL("jar:" + path.toUri().toURL() + jarFolderReference);
     }
 

--- a/sapl-pdp-embedded/src/test/java/io/sapl/util/JarUtilTests.java
+++ b/sapl-pdp-embedded/src/test/java/io/sapl/util/JarUtilTests.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.mockStatic;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.util.zip.ZipFile;
@@ -59,7 +60,8 @@ class JarUtilTests {
     }
 
     @Test
-    void readStringFromZipEntryTest(@TempDir(cleanup = CleanupMode.ALWAYS) Path tempDir) throws IOException {
+    void readStringFromZipEntryTest(@TempDir(cleanup = CleanupMode.ALWAYS) Path tempDir)
+            throws IOException, URISyntaxException {
         var url       = JarCreator.createPoliciesInJar("!/policies", tempDir);
         var pathOfJar = JarUtil.getJarFilePath(url);
         try (var jarFile = new ZipFile(pathOfJar)) {
@@ -71,7 +73,7 @@ class JarUtilTests {
 
     @Test
     void readStringFromZipEntryTestWithErrorPropagation(@TempDir(cleanup = CleanupMode.ALWAYS) Path tempDir)
-            throws IOException {
+            throws IOException, URISyntaxException {
         var url       = JarCreator.createPoliciesInJar("!/policies", tempDir);
         var pathOfJar = JarUtil.getJarFilePath(url);
         try (MockedStatic<IOUtils> mock = mockStatic(IOUtils.class)) {


### PR DESCRIPTION
<!-- This PR fixes #NUMBER_OF_THE_ISSUE, and fixes #NUMBER_OF_THE_ISSUE -->

## Description

Instead of resolving a string path use URI to reference resources.
Further minimal improvements to code.

Did check against pipelines on my fork so that everything works and runs on any OS now.

![image](https://github.com/heutelbeck/sapl-policy-engine/assets/22798149/da00c3f4-f7c5-4044-8cfb-4cb86dbdd435)

So it should work now...

If anything breaks again, please reach out again. I will fix it!

## Checklist

<!--
Fill out and perform the following checklist before publishing the PR for review.
-->

* [X] I have updated the documentation accordingly.
* [X] I have added tests to cover my changes.
* [X] All new and existing tests passed.
* [X] My code follows the code style of this project.
* [X] I ran all checks which produced no new errors or warnings for my changes.
* [X] I have checked to ensure there aren't other open Pull Requests for the same update/change.

<!-- 📛📛📛
All pull requests go through pipelines and careful peer review to ensure the quality of the code, but this does not exempt developers from delivering good code. 
Write code to the best of your ability while considering best practices, guidelines, and requirements.

If it fixes any current issues please let us know this way:
Uncomment the comment above the "description", then add your number of issues after the "#".
Example: # **This pull request fixes #NUMBER_OF_THE_ISSUE issue**
If there are multiple issues to be closed with the merge of this pull request
please do it like so: **This pull request fixes #NUMBER_OF_THE_ISSUE, fixes #NUMBER_OF_THE_ISSUE and fixes #NUMBER_OF_THE_ISSUE issue**.
For more information on closing issues using keywords, please check https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords#closing-multiple-issues
📛📛📛 -->
