### PR TITLE
fix not closing hint widget on click in SAPLEditor 

### DIFF
--- a/sapl-vaadin-editor/src/main/resources/META-INF/resources/frontend/sapl-editor.js
+++ b/sapl-vaadin-editor/src/main/resources/META-INF/resources/frontend/sapl-editor.js
@@ -108,7 +108,8 @@ class SAPLEditor extends LitElement {
       gutters: ["CodeMirror-lint-markers"],
       extraKeys: {"Ctrl-Space": "autocomplete"},
       hintOptions: {
-        container: widget_container
+        container: widget_container,
+        updateOnCursorActivity: false
       },
       theme: "default"
     });


### PR DESCRIPTION
since update of codemirror5 version from 5.52.2 to 5.65.16 (currently latest) hints for code completion were not closed when an value in hint widget was clicked. therefore disabled the option updateOnCursorActivity for the hint widget introduced in codemirror version 5.59.0

<!-- This PR fixes #NUMBER_OF_THE_ISSUE, and fixes #NUMBER_OF_THE_ISSUE -->

## Description

<!--
Include a concise description of the changes (bug or feature), 
its impact, along with a summary of the solution
-->


## Checklist

<!--
Fill out and perform the following checklist before publishing the PR for review.
-->

* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran all checks which produced no new errors or warnings for my changes.
* [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.

<!-- 📛📛📛
All pull requests go through pipelines and careful peer review to ensure the quality of the code, but this does not exempt developers from delivering good code. 
Write code to the best of your ability while considering best practices, guidelines, and requirements.

If it fixes any current issues please let us know this way:
Uncomment the comment above the "description", then add your number of issues after the "#".
Example: # **This pull request fixes #NUMBER_OF_THE_ISSUE issue**
If there are multiple issues to be closed with the merge of this pull request
please do it like so: **This pull request fixes #NUMBER_OF_THE_ISSUE, fixes #NUMBER_OF_THE_ISSUE and fixes #NUMBER_OF_THE_ISSUE issue**.
For more information on closing issues using keywords, please check https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords#closing-multiple-issues
📛📛📛 -->
