### PR TITLE
Avoid warning when building with java 21

### DIFF
--- a/sapl-eclipse-plugin/sapl-eclipse-ui/META-INF/MANIFEST.MF
+++ b/sapl-eclipse-plugin/sapl-eclipse-ui/META-INF/MANIFEST.MF
@@ -20,7 +20,6 @@ Require-Bundle: sapl-lang,
  org.eclipse.compare,
  org.eclipse.xtext.builder
 Import-Package: org.apache.log4j
-Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: io.sapl.grammar.ui.quickfix,
  io.sapl.grammar.ui.contentassist,
  sapl_eclipse_ui.internal


### PR DESCRIPTION
## Description

The build log currently contains the warning "Using JavaSE-21 to fulfill requested profile of JavaSE-17. This might lead to faulty dependency resolution, consider defining a suitable JDK in the toolchains.xml." when building with java 21 although it is fine to build the project with java 21. 
It is not possible to "RequiredExecutionEnvironment" because it would break the build with java 17. This PR remove "RequiredExecutionEnvironment" so that the build can run with java 17 and 21 without the mentioned warning.

## Checklist

<!--
Fill out and perform the following checklist before publishing the PR for review.
-->

* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [X] All new and existing tests passed.
* [X] My code follows the code style of this project.
* [X] I ran all checks which produced no new errors or warnings for my changes.
* [X] I have checked to ensure there aren't other open Pull Requests for the same update/change.

<!-- 📛📛📛
All pull requests go through pipelines and careful peer review to ensure the quality of the code, but this does not exempt developers from delivering good code. 
Write code to the best of your ability while considering best practices, guidelines, and requirements.

If it fixes any current issues please let us know this way:
Uncomment the comment above the "description", then add your number of issues after the "#".
Example: # **This pull request fixes #NUMBER_OF_THE_ISSUE issue**
If there are multiple issues to be closed with the merge of this pull request
please do it like so: **This pull request fixes #NUMBER_OF_THE_ISSUE, fixes #NUMBER_OF_THE_ISSUE and fixes #NUMBER_OF_THE_ISSUE issue**.
For more information on closing issues using keywords, please check https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords#closing-multiple-issues
📛📛📛 -->
